### PR TITLE
Add ocamlbuild 0.15.0+jst

### DIFF
--- a/packages/ocamlbuild.0.15.0+jst/files/flambda2.patch
+++ b/packages/ocamlbuild.0.15.0+jst/files/flambda2.patch
@@ -1,0 +1,48 @@
+diff --git a/Makefile b/Makefile
+index 3039625..1344f79 100644
+--- a/Makefile
++++ b/Makefile
+@@ -412,10 +412,22 @@ endif
+ 
+ # The generic rules
+ 
+-%.cmo: %.ml
++src/%.cmo: src/%.ml
++	$(OCAMLC) -for-pack Ocamlbuild_pack $(OCB_COMPFLAGS) -c $<
++
++bin/%.cmo: bin/%.ml
++	$(OCAMLC) $(OCB_COMPFLAGS) -c $<
++
++plugin-lib/%.cmo: plugin-lib/%.ml
++	$(OCAMLC) $(OCB_COMPFLAGS) -c $<
++
++src/%.cmi: src/%.mli
++	$(OCAMLC) -for-pack Ocamlbuild_pack $(OCB_COMPFLAGS) -c $<
++
++bin/%.cmi: bin/%.mli
+ 	$(OCAMLC) $(OCB_COMPFLAGS) -c $<
+ 
+-%.cmi: %.mli
++plugin-lib/%.cmi: plugin-lib/%.mli
+ 	$(OCAMLC) $(OCB_COMPFLAGS) -c $<
+ 
+ src/%.cmx: src/%.ml
+diff --git a/src/configuration.ml b/src/configuration.ml
+index a209df5..ec620d0 100644
+--- a/src/configuration.ml
++++ b/src/configuration.ml
+@@ -58,6 +58,14 @@ let apply_config s (config : t) init =
+   List.fold_left begin fun tags (key, v) ->
+     if key_match key s then
+       List.fold_right add v.plus_tags (List.fold_right remove v.minus_tags tags)
++    else if
++         List.mem (Filename.extension s) [".ml"; ".mli"]
++      && key_match key (Filename.remove_extension s ^ ".cmx")
++    then
++      let only_for_pack l =
++        List.filter (fun (tag, _) -> String.length tag >= 9 && String.sub tag 0 9 = "for-pack(") l
++      in
++      List.fold_right add (only_for_pack v.plus_tags) (List.fold_right remove (only_for_pack v.minus_tags) tags)
+     else tags
+   end init config
+ 

--- a/packages/ocamlbuild.0.15.0+jst/opam
+++ b/packages/ocamlbuild.0.15.0+jst/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Gabriel Scherer <gabriel.scherer@gmail.com>"
+authors: ["Nicolas Pouillard" "Berke Durak"]
+homepage: "https://github.com/ocaml/ocamlbuild/"
+bug-reports: "https://github.com/ocaml/ocamlbuild/issues"
+license: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+doc: "https://github.com/ocaml/ocamlbuild/blob/master/manual/manual.adoc"
+dev-repo: "git+https://github.com/ocaml/ocamlbuild.git"
+synopsis:
+  "OCamlbuild is a build system with builtin rules to easily build most OCaml projects"
+
+build: [
+  [
+    make
+    "-f"
+    "configure.make"
+    "all"
+    "OCAMLBUILD_PREFIX=%{prefix}%"
+    "OCAMLBUILD_BINDIR=%{bin}%"
+    "OCAMLBUILD_LIBDIR=%{lib}%"
+    "OCAMLBUILD_MANDIR=%{man}%"
+    "OCAML_NATIVE=%{ocaml:native}%"
+    "OCAML_NATIVE_TOOLS=%{ocaml:native}%"
+  ]
+  [make "check-if-preinstalled" "all" "opam-install"]
+]
+
+conflicts: [
+  "base-ocamlbuild"
+  "ocamlfind" {< "1.6.2"}
+]
+
+depends: [
+  "ocaml" {>= "4.08"}
+  "ocamlfind" {with-test}
+  "menhirLib" {with-test}
+]
+
+url {
+  src: "https://github.com/ocaml/ocamlbuild/archive/refs/tags/0.15.0.tar.gz"
+  checksum: [
+    "sha512=c8311a9a78491bf759eb27153d6ba4692d27cd935759a145f96a8ba8f3c2e97cef54e7d654ed1c2c07c74f60482a4fef5224e26d0f04450e69cdcb9418c762d3"
+  ]
+}
+patches: ["flambda2.patch"]
+extra-files: [ ["flambda2.patch" "md5=f98a89ce2f1da3a366e0226905a726e9" ] ]


### PR DESCRIPTION
Fix ocamlbuild for 5.2+flambda. (ocamlbuild.0.14.2+jst is no longer supported in OCaml 5.2 &mdash; the same is true for upstream.)