### PR TITLE
Fix starter packages for 5.2 in with-extensions-dev

### DIFF
--- a/packages/dot-merlin-reader.5.2.1-502+jst/opam
+++ b/packages/dot-merlin-reader.5.2.1-502+jst/opam
@@ -23,5 +23,7 @@ url {
   src:
     "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
   checksum: [
+    "sha256=a38947c8a21c519e4891b3249671c050e593110ccfc0be64ee601dd951888f86"
+    "sha512=bf8522f92332bcb0f708d4460c4f7602c25afe58268782c5f9caf26a3933da47288ea6117701a86a691e9ab6d098e6282cca88753c28607334ddc403fb9ef105"
   ]
 }

--- a/packages/dot-merlin-reader.5.2.1-502+jst/opam
+++ b/packages/dot-merlin-reader.5.2.1-502+jst/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/janestreet/merlin-jst"
+bug-reports:  "https://github.com/janestreet/merlin-jst/issues"
+dev-repo:     "git+https://github.com/janestreet/merlin-jst.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "3.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
+  checksum: [
+  ]
+}

--- a/packages/jsonrpc.1.19.0+jst/opam
+++ b/packages/jsonrpc.1.19.0+jst/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implemenation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/janestreet/ocaml-lsp"
+bug-reports: "https://github.com/janestreet/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/janestreet/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/janestreet/ocaml-lsp/archive/56045172dfa078eb53c9ac1e3cdd18cd4646b90a.tar.gz"
+    checksum: [
+      "sha256=e73c413efd28e2f5be63cf468662083f724bb2dc575883cc36fba054857c749b"
+      "sha512=c44d093e7d43bccbcfe77ef9d47a5163d9644acca312ea0d3edbf6f59d10a36a4d2081614b7ecfa7027b807cfc352c6d5fff81d7d619f6032f07f3ca38aaff39"
+    ]
+}
+x-commit-hash: "56045172dfa078eb53c9ac1e3cdd18cd4646b90a"

--- a/packages/lsp.1.19.0+jst/opam
+++ b/packages/lsp.1.19.0+jst/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/janestreet/ocaml-lsp"
+bug-reports: "https://github.com/janestreet/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.15.0" & < "0.17.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+]
+dev-repo: "git+https://github.com/janestreet/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/janestreet/ocaml-lsp/archive/56045172dfa078eb53c9ac1e3cdd18cd4646b90a.tar.gz"
+    checksum: [
+      "sha256=e73c413efd28e2f5be63cf468662083f724bb2dc575883cc36fba054857c749b"
+      "sha512=c44d093e7d43bccbcfe77ef9d47a5163d9644acca312ea0d3edbf6f59d10a36a4d2081614b7ecfa7027b807cfc352c6d5fff81d7d619f6032f07f3ca38aaff39"
+    ]
+}
+x-commit-hash: "56045172dfa078eb53c9ac1e3cdd18cd4646b90a"

--- a/packages/merlin-lib.5.2.1-502+jst/opam
+++ b/packages/merlin-lib.5.2.1-502+jst/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/janestreet/merlin-jst"
+bug-reports:  "https://github.com/janestreet/merlin-jst/issues"
+dev-repo:     "git+https://github.com/janestreet/merlin-jst.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test}
+  "menhir"    {dev & >= "20201216"}
+  "menhirLib" {dev & >= "20201216"}
+  "menhirSdk" {dev & >= "20201216"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
+  checksum: [
+  ]
+}

--- a/packages/merlin-lib.5.2.1-502+jst/opam
+++ b/packages/merlin-lib.5.2.1-502+jst/opam
@@ -28,5 +28,7 @@ url {
   src:
     "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
   checksum: [
+    "sha256=a38947c8a21c519e4891b3249671c050e593110ccfc0be64ee601dd951888f86"
+    "sha512=bf8522f92332bcb0f708d4460c4f7602c25afe58268782c5f9caf26a3933da47288ea6117701a86a691e9ab6d098e6282cca88753c28607334ddc403fb9ef105"
   ]
 }

--- a/packages/merlin.5.2.1-502+jst/opam
+++ b/packages/merlin.5.2.1-502+jst/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin-jst"
+bug-reports:  "https://github.com/ocaml/merlin-jst/issues"
+dev-repo:     "git+https://github.com/janestreet/merlin-jst.git"
+license:      "MIT"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.2" & < "5.3"}
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {>= "1.0" & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+  "alcotest" {with-test}
+]
+conflicts: [
+  "seq" {!= "base"}
+  "base-effects"
+]
+synopsis:
+  "Editor helper, provides completion, typing and source browsing in Vim and Emacs"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features available in modern IDEs: error reporting, auto completion, source browsing and much more."
+post-messages: [
+  "merlin installed.
+
+Quick setup for VIM
+-------------------
+Append this to your .vimrc to add merlin to vim's runtime-path:
+  let g:opamshare = substitute(system('opam var share'),'\\n$','','''')
+  execute \"set rtp+=\" . g:opamshare . \"/merlin/vim\"
+
+Also run the following line in vim to index the documentation:
+  :execute \"helptags \" . g:opamshare . \"/merlin/vim/doc\"
+
+Quick setup for EMACS
+-------------------
+Add opam emacs directory to your load-path by appending this to your .emacs:
+  (let ((opam-share (ignore-errors (car (process-lines \"opam\" \"var\" \"share\")))))
+   (when (and opam-share (file-directory-p opam-share))
+    ;; Register Merlin
+    (add-to-list 'load-path (expand-file-name \"emacs/site-lisp\" opam-share))
+    (autoload 'merlin-mode \"merlin\" nil t nil)
+    ;; Automatically start it in OCaml buffers
+    (add-hook 'tuareg-mode-hook 'merlin-mode t)
+    (add-hook 'caml-mode-hook 'merlin-mode t)
+    ;; Use opam switch to lookup ocamlmerlin binary
+    (setq merlin-command 'opam)
+    ;; To easily change opam switches within a given Emacs session, you can
+    ;; install the minor mode https://github.com/ProofGeneral/opam-switch-mode
+    ;; and use one of its \"OPSW\" menus.
+    ))
+Take a look at https://github.com/ocaml/merlin for more information
+
+Quick setup with opam-user-setup
+--------------------------------
+
+Opam-user-setup support Merlin.
+
+  $ opam user-setup install
+
+should take care of basic setup.
+See https://github.com/OCamlPro/opam-user-setup
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
+  checksum: [
+  ]
+}

--- a/packages/merlin.5.2.1-502+jst/opam
+++ b/packages/merlin.5.2.1-502+jst/opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
 maintainer:   "defree@gmail.com"
 authors:      "The Merlin team"
-homepage:     "https://github.com/ocaml/merlin-jst"
-bug-reports:  "https://github.com/ocaml/merlin-jst/issues"
+homepage:     "https://github.com/janestreet/merlin-jst"
+bug-reports:  "https://github.com/janestreet/merlin-jst/issues"
 dev-repo:     "git+https://github.com/janestreet/merlin-jst.git"
 license:      "MIT"
 build: [
@@ -76,5 +76,7 @@ url {
   src:
     "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
   checksum: [
+    "sha256=a38947c8a21c519e4891b3249671c050e593110ccfc0be64ee601dd951888f86"
+    "sha512=bf8522f92332bcb0f708d4460c4f7602c25afe58268782c5f9caf26a3933da47288ea6117701a86a691e9ab6d098e6282cca88753c28607334ddc403fb9ef105"
   ]
 }

--- a/packages/ocaml-index.1.1+jst/opam
+++ b/packages/ocaml-index.1.1+jst/opam
@@ -34,5 +34,7 @@ url {
   src:
     "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
   checksum: [
+    "sha256=a38947c8a21c519e4891b3249671c050e593110ccfc0be64ee601dd951888f86"
+    "sha512=bf8522f92332bcb0f708d4460c4f7602c25afe58268782c5f9caf26a3933da47288ea6117701a86a691e9ab6d098e6282cca88753c28607334ddc403fb9ef105"
   ]
 }

--- a/packages/ocaml-index.1.1+jst/opam
+++ b/packages/ocaml-index.1.1+jst/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/janestreet/merlin-jst"
+bug-reports: "https://github.com/janestreet/merlin-jst/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "5.2"}
+  "merlin-lib" {>= "5.2.1-502"}
+  "odoc" {with-doc}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+url {
+  src:
+    "https://github.com/janestreet/merlin-jst/archive/6362f77bfe49dc5556763dfe500e784a3fccafc9.tar.gz"
+  checksum: [
+  ]
+}

--- a/packages/ocaml-lsp-server.1.19.0+jst/opam
+++ b/packages/ocaml-lsp-server.1.19.0+jst/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/janestreet/ocaml-lsp"
+bug-reports: "https://github.com/janestreet/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base" {>= "v0.16.0"}
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.4.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune"
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "5.2.0" & < "5.3.0"}
+  "xdg"
+  "ordering"
+  "dune-build-info"
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.15.0" & < "0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.26.2"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "5.0" & < "6.0"}
+  "ocaml-index" {>= "1.0" & post}
+]
+dev-repo: "git+https://github.com/janestreet/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/janestreet/ocaml-lsp/archive/56045172dfa078eb53c9ac1e3cdd18cd4646b90a.tar.gz"
+  checksum: [
+    "sha256=e73c413efd28e2f5be63cf468662083f724bb2dc575883cc36fba054857c749b"
+    "sha512=c44d093e7d43bccbcfe77ef9d47a5163d9644acca312ea0d3edbf6f59d10a36a4d2081614b7ecfa7027b807cfc352c6d5fff81d7d619f6032f07f3ca38aaff39"
+  ]
+}
+x-commit-hash: "56045172dfa078eb53c9ac1e3cdd18cd4646b90a"

--- a/packages/ocamlformat-lib.0.26.2+jst/opam
+++ b/packages/ocamlformat-lib.0.26.2+jst/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "OCaml Code Formatter"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/janestreet/ocamlformat"
+bug-reports: "https://github.com/janestreet/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08" & < "5.3"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "result"
+  "camlp-streams"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/ocamlformat.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/janestreet/ocamlformat/archive/1103e7246de6dac0d3f5a639f5dbe7b6a3530cf8.tar.gz"
+    checksum: [
+      "sha256=c535d678cf3ed7d18590f09f3bbabe5e7ad26f566bfbd0bb500cbc7c0b767847"
+      "sha512=e65102673b29d3358b6f0b01fe7bc6a4dc2ca25f70824258de6e993f348626d592005c9fb02cdeed5b19628aade0223495c3cee52cc554af1ba7ab60ffd7fd6d"
+    ]
+}
+x-commit-hash: "1103e7246de6dac0d3f5a639f5dbe7b6a3530cf8"

--- a/packages/ocamlformat.0.26.2+jst/opam
+++ b/packages/ocamlformat.0.26.2+jst/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description: """
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+  "Emile Trotignon <emile@tarides.com>"
+]
+authors: [
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/janestreet/ocamlformat"
+bug-reports: "https://github.com/janestreet/ocamlformat/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
+  "dune" {>= "2.8"}
+  "ocamlformat-lib" {= version}
+  "ocamlformat-rpc-lib" {with-test & = version}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/ocamlformat.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/janestreet/ocamlformat/archive/1103e7246de6dac0d3f5a639f5dbe7b6a3530cf8.tar.gz"
+  checksum: [
+    "sha256=c535d678cf3ed7d18590f09f3bbabe5e7ad26f566bfbd0bb500cbc7c0b767847"
+    "sha512=e65102673b29d3358b6f0b01fe7bc6a4dc2ca25f70824258de6e993f348626d592005c9fb02cdeed5b19628aade0223495c3cee52cc554af1ba7ab60ffd7fd6d"
+  ]
+}
+x-commit-hash: "1103e7246de6dac0d3f5a639f5dbe7b6a3530cf8"

--- a/packages/utop.2.14.0+jst/opam
+++ b/packages/utop.2.14.0+jst/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Universal toplevel for OCaml"
+description:
+  "utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for OCaml. It can run in a terminal or in Emacs. It supports line edition, history, real-time and context sensitive completion, colors, and more. It integrates with the Tuareg mode in Emacs."
+maintainer: ["jeremie@dimino.org"]
+authors: ["Jérémie Dimino"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/janestreet/utop"
+doc: "https://ocaml-community.github.io/utop/"
+bug-reports: "https://github.com/janestreet/utop/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.11.0" & < "5.3"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "3.1.0" & < "4.0"}
+  "logs"
+  "lwt"
+  "lwt_react"
+  "zed" {>= "3.2.0"}
+  "react" {>= "1.0.0"}
+  "cppo" {>= "1.1.2"}
+  "alcotest" {with-test}
+  "xdg" {>= "3.9.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/janestreet/utop.git"
+url {
+  src:
+    "https://github.com/janestreet/utop/archive/69f5b21097cf5ed2e02b4cf850f10f10c1496f31.tar.gz"
+  checksum: [
+    "sha256=7bc808f046822d694dca9e48f14db923e013f17cd7a363ff44c7572528eb01ba"
+    "sha512=87126a7fd4c6213e6d562e577dfaba2910f70d19b0ddc0e2c53c1f5630650803e070835b0688f129d226b9d08d6bf720dee1a59faa2d0238ba63a521b10017f9"
+  ]
+}
+x-commit-hash: "69f5b21097cf5ed2e02b4cf850f10f10c1496f31"


### PR DESCRIPTION
Add patched versions of:
  * merlin (and its ecosystem)
    * https://github.com/janestreet/merlin-jst/pull/111
  * lsp (and its ecosystem)
    * https://github.com/janestreet/ocaml-lsp/tree/with-extensions
  * utop
      * https://github.com/janestreet/utop/tree/with-extensions
  * ocamlformat
      * https://github.com/janestreet/ocamlformat/tree/with-extensions

We should make sure the branches above are in a good state before merging this.