### PR TITLE
add fix for arm64 build on linux

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.2.0+flambda2/files/fix-arm64-asm.patch
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+flambda2/files/fix-arm64-asm.patch
@@ -1,0 +1,15 @@
+diff --git a/ocaml/runtime/arm64.S b/ocaml/runtime/arm64.S
+index 79f6f41245..0dddf12111 100644
+--- a/ocaml/runtime/arm64.S
++++ b/ocaml/runtime/arm64.S
+@@ -568,7 +568,7 @@ L(caml_call_local_realloc):
+         ldp     x29, x30, [sp], 16
+         ret
+         CFI_ENDPROC
+-        END_FUNCTION(caml_call_gc)
++END_FUNCTION(caml_call_local_realloc)
+ 
+ /* Call a C function from OCaml */
+ /* Function to call is in ADDITIONAL_ARG */
+-- 
+

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+flambda2/opam
@@ -35,8 +35,10 @@ url {
 extra-files: [
   ["meta.patch" "sha256=3f165d873951620a3189938a909305aa0de3c77b998b6c84125f39ae95e91fb2"]
   ["remove-sigwait.patch" "sha256=1983f61bd5a53cd9918acd297c40ea5327370325c2974c18dfdcd21f9f0cac20"]
+  ["fix-arm64-asm.patch" "sha256=bbfcfe847b62aceeae65331168ab2de68a9264651cf5abcb41d3502c54f7a506"]
 ]
 patches: [
   "meta.patch"
   "remove-sigwait.patch"
+  "fix-arm64-asm.patch"
 ]


### PR DESCRIPTION
Backport https://github.com/ocaml-flambda/flambda-backend/pull/3533, which fixes a trivial bug in the arm64 runtime asm due to a mismatching `END_FUNCTION` directive.