### PR TITLE
fix for async_ssl

### DIFF
--- a/packages/async_ssl.v0.18~preview.130.04+450/files/fix-on-aarch64.patch
+++ b/packages/async_ssl.v0.18~preview.130.04+450/files/fix-on-aarch64.patch
@@ -1,0 +1,23 @@
+diff --git a/src/dune b/src/dune
+index bf67dbc..f351ed4 100644
+--- a/src/dune
++++ b/src/dune
+@@ -24,7 +24,7 @@
+   (language c)
+   (names ffi_generated_stubs)
+   (flags
+-   (:standard \ -Werror -pedantic -Wall -Wunused -Wincompatible-pointer-types)
++   (:standard -Werror -pedantic -Wall -Wunused -Wno-incompatible-pointer-types)
+    -w
+    (:include ../bindings/openssl-ccopt.sexp)
+    -Wno-int-conversion
+@@ -36,6 +36,7 @@
+  (flags :standard -w -9-27-32-34)
+  (c_library_flags
+   :standard
++  -Wno-incompatible-pointer-types
+   (:include ../bindings/openssl-cclib.sexp))
+  (libraries async core async_ssl_bindings ctypes.stubs ctypes integers)
+  (preprocess
+-- 
+

--- a/packages/async_ssl.v0.18~preview.130.04+450/opam
+++ b/packages/async_ssl.v0.18~preview.130.04+450/opam
@@ -34,3 +34,9 @@ url {
 src: "https://github.com/janestreet/async_ssl/archive/fd31f0aa87837d8f2a2d47620d8288d4f6aef4c4.tar.gz"
 checksum: "sha256=4d001b8b00c806e96ec914aced34642df956b02c3719ca75dadfe6bbe8e5c7ea"
 }
+extra-files: [
+  ["fix-on-aarch64.patch" "sha256=c13895bf9378c49e3c45092e4fed3dbf2340cc30f65e365cfee6bcbe070d1af1"]
+]
+patches: [
+  "fix-on-aarch64.patch"
+]


### PR DESCRIPTION
Add a patch corresponding to the conclusion of https://github.com/janestreet/async_ssl/issues/39 to allow async_ssl to build on modern toolchains (e.g. arm64 linux). I've tested this patch myself on an arm64 linux system, and it builds correctly.