### PR TITLE
fix alcotest

### DIFF
--- a/packages/alcotest.1.9.0+jst/files/local-restriction.patch
+++ b/packages/alcotest.1.9.0+jst/files/local-restriction.patch
@@ -1,0 +1,11 @@
+--- a/src/alcotest-stdlib-ext/alcotest_stdlib_ext.ml
++++ b/src/alcotest-stdlib-ext/alcotest_stdlib_ext.ml
+@@ -15,7 +15,7 @@ end
+ module String = struct
+   include Astring.String
+
+-  let length_utf8 = Uutf.String.fold_utf_8 (fun count _ _ -> count + 1) 0
++  let length_utf8 t = Uutf.String.fold_utf_8 (fun count _ _ -> count + 1) 0 t
+
+   let prefix_utf8 uchars string =
+     let exception Found_new_length of int in

--- a/packages/alcotest.1.9.0+jst/opam
+++ b/packages/alcotest.1.9.0+jst/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+name: "alcotest"
+version: "1.9.0+jst"
+synopsis: "Alcotest is a lightweight and colourful test framework"
+description: """\
+Alcotest exposes simple interface to perform unit tests. It exposes
+a simple TESTABLE module type, a check function to assert test
+predicates and a run function to perform a list of unit -> unit
+test callbacks.
+
+Alcotest provides a quiet and colorful output where only faulty runs
+are fully displayed at the end of the run (with the full logs ready to
+inspect), with a simple (yet expressive) query language to select the
+tests to run."""
+maintainer: "thomas@gazagnaire.org"
+authors: "Thomas Gazagnaire"
+license: "ISC"
+homepage: "https://github.com/mirage/alcotest"
+doc: "https://mirage.github.io/alcotest"
+bug-reports: "https://github.com/mirage/alcotest/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "astring"
+  "cmdliner" {>= "1.2.0"}
+  "re" {>= "1.7.2"}
+  "stdlib-shims"
+  "uutf" {>= "1.0.1"}
+  "ocaml-syntax-shims"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "js_of_ocaml-compiler" {< "5.8"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/alcotest.git"
+url {
+  src:
+    "https://github.com/mirage/alcotest/releases/download/1.9.0/alcotest-1.9.0.tbz"
+  checksum: [
+    "sha256=e2387136ca854df2b4152139dd4d4b3953a646e804948073dedfe0a232f08a15"
+    "sha512=ba38fe4a9061b001d274e5d41fb06c10c84120570fc00dc57dc5a06ba05176c2413295680d839f465ba91469ea99d7e172a324e26f005d6e8c4d98fca7657241"
+  ]
+}
+x-commit-hash: "263a4245071f6dad243a3d72d9dd875b2bd267a0"
+x-maintenance-intent: ["(latest)"]
+patches: [
+  "local-restriction.patch"
+]
+extra-files: [
+  [
+    "local-restriction.patch"
+    "sha256=f5434f07bed278f6aaf882c8ff276b10e1a9cf8f951e60386f20aa5d4da8c911"
+  ]
+]


### PR DESCRIPTION
```
File "src/alcotest-stdlib-ext/alcotest_stdlib_ext.ml", line 18, characters 6-17:
18 |   let length_utf8 = Uutf.String.fold_utf_8 (fun count _ _ -> count + 1) 0
           ^^^^^^^^^^^
Error: This value is local, but expected to be global because it is inside a module.
```

I'll suggest the change to alcotest too but it may take some time before it is released.