### PR TITLE
fix init-compiler: use 4.14.2

### DIFF
--- a/packages/init-compiler/init-compiler.4.14.2/opam
+++ b/packages/init-compiler/init-compiler.4.14.2/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "4.14.2 compiler used for bootstraping"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+]
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%/init_deps"
+    "--disable-ocamldoc"
+    "--docdir=%{prefix}%/doc/ocaml"
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/4.14.2.tar.gz"
+  checksum: "sha256=c2d706432f93ba85bd3383fa451d74543c32a4e84a1afaf3e8ace18f7f097b43"
+}

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+flambda2/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+flambda2/opam
@@ -6,7 +6,7 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml-flambda/flambda-backend/issues"
 dev-repo: "git+https://github.com/ocaml-flambda/flambda-backend#main"
 depends: [
-  "init-compiler"
+  "init-compiler" {= "4.14.2"}
   "init-dune"
   "init-menhir"
   "ocaml" {= "5.2.0" & post}


### PR DESCRIPTION
Archlinux users have confirmed that this patch enable them to set up an OxCaml switch, as [OCaml 4.14.2 fixed a bunch of stuff](https://github.com/ocaml/ocaml/blob/4.14/Changes#L57), including the compilation issue they were facing in ocaml 4.14.1 with a recent gcc v15.

(Many thanks to @fabbing for the report and help!)