### PR TITLE
jsoo-toplevel: patch jsoo-toplevel

### DIFF
--- a/packages/js_of_ocaml-compiler.6.0.1+jst/files/js_of_ocaml-top-effects.patch
+++ b/packages/js_of_ocaml-compiler.6.0.1+jst/files/js_of_ocaml-top-effects.patch
@@ -1,0 +1,16 @@
+diff --git a/runtime/js/jslib.js b/runtime/js/jslib.js
+index 6a711bbb1d..081361a841 100644
+--- a/runtime/js/jslib.js
++++ b/runtime/js/jslib.js
+@@ -134,8 +134,9 @@ function caml_jsoo_flags_use_js_string(unit) {
+ }
+ 
+ //Provides: caml_jsoo_flags_effects
++//Requires: caml_string_of_jsstring
+ function caml_jsoo_flags_effects(unit) {
+-  return CONFIG("effects");
++  return caml_string_of_jsstring(CONFIG("effects"));
+ }
+ 
+ //Provides: caml_wrap_exception const (mutable)
+

--- a/packages/js_of_ocaml-compiler.6.0.1+jst/files/js_of_ocaml-toplevel.patch
+++ b/packages/js_of_ocaml-compiler.6.0.1+jst/files/js_of_ocaml-toplevel.patch
@@ -1,0 +1,238 @@
+diff --git a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+index 140a53b..d857289 100644
+--- a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
++++ b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+@@ -4,7 +4,7 @@ module J = Jsoo_runtime.Js
+
+ type bytecode_sections =
+   { symb : Ocaml_compiler.Symtable.GlobalMap.t
+-  ; crcs : (string * Digest.t option) list
++  ; crcs : Import_info.t array
+   ; prim : string list
+   ; dlpt : string list
+   }
+diff --git a/compiler/lib/link_js.ml b/compiler/lib/link_js.ml
+index 68f0c32..3ec9ddc 100644
+--- a/compiler/lib/link_js.ml
++++ b/compiler/lib/link_js.ml
+@@ -426,7 +426,7 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~(sourc
+             List.fold_left units ~init:StringSet.empty ~f:(fun acc (u : Unit_info.t) ->
+                 StringSet.union acc (StringSet.of_list u.primitives))
+           in
+-          let code = Parse_bytecode.link_info ~symbols:!sym ~primitives ~crcs:[] in
++          let code = Parse_bytecode.link_info ~symbols:!sym ~primitives ~crcs:[||] in
+           let b = Buffer.create 100 in
+           let fmt = Pretty_print.to_buffer b in
+           Driver.configure fmt;
+diff --git a/compiler/lib/parse_bytecode.ml b/compiler/lib/parse_bytecode.ml
+index 79e0c8f..bf8751a 100644
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -35,6 +35,9 @@ let predefined_exceptions =
+
+ let new_closure_repr = Ocaml_version.compare Ocaml_version.current [ 4; 12 ] >= 0
+
++let crc_name v = Import_info.name v |> Compilation_unit.Name.to_string
++let crc_crc v = Import_info.crc v
++
+ (* Read and manipulate debug section *)
+ module Debug : sig
+   type t
+@@ -76,11 +79,11 @@ module Debug : sig
+     -> unit
+
+   val read :
+-    t -> crcs:(string * string option) list -> includes:string list -> in_channel -> unit
++    t -> crcs:Import_info.t list -> includes:string list -> in_channel -> unit
+
+   val read_event_list :
+        t
+-    -> crcs:(string * string option) list
++    -> crcs:Import_info.t list
+     -> includes:string list
+     -> orig:int
+     -> in_channel
+@@ -146,6 +149,7 @@ end = struct
+     | Some _ as x -> x
+     | None -> Fs.find_in_path paths (name ^ ".ml")
+
++
+   let read_event
+       ~paths
+       ~crcs
+@@ -216,7 +220,7 @@ end = struct
+     fun debug ~crcs ~includes ~orig ic ->
+       let crcs =
+         let t = Hashtbl.create 17 in
+-        List.iter crcs ~f:(fun (m, crc) -> Hashtbl.add t m crc);
++        List.iter crcs ~f:(fun i -> Hashtbl.add t (crc_name i) (crc_crc i));
+         t
+       in
+       let evl : debug_event list = input_value ic in
+@@ -2520,7 +2524,7 @@ module Toc : sig
+
+   val read_data : t -> in_channel -> Obj.t array
+
+-  val read_crcs : t -> in_channel -> (string * Digest.t option) list
++  val read_crcs : t -> in_channel -> Import_info.t array
+
+   val read_prim : t -> in_channel -> string
+
+@@ -2570,9 +2574,10 @@ end = struct
+   let read_crcs toc ic =
+     ignore (seek_section toc ic "CRCS");
+     let orig_crcs : Import_info.t array = input_value ic in
+-    List.map (Array.to_list orig_crcs) ~f:(fun import ->
+-      Import_info.name import |> Compilation_unit.Name.to_string,
+-      Import_info.crc import)
++    orig_crcs
++    (* List.map (Array.to_list orig_crcs) ~f:(fun import -> *)
++    (*   Import_info.name import |> Compilation_unit.Name.to_string, *)
++    (*   Import_info.crc import) *)
+
+   let read_prim toc ic =
+     let prim_size = seek_section toc ic "PRIM" in
+@@ -2587,12 +2592,13 @@ let read_primitives toc ic =
+
+ type bytesections =
+   { symb : Ocaml_compiler.Symtable.GlobalMap.t
+-  ; crcs : (string * Digest.t option) list
++  ; crcs : Import_info.t array
+   ; prim : string list
+   ; dlpt : string list
+   }
+ [@@ocaml.warning "-unused-field"]
+
++
+ let from_exe
+     ?(includes = [])
+     ~linkall
+@@ -2625,7 +2631,7 @@ let from_exe
+       | Some l -> List.mem s ~set:l
+       | None -> true)
+   in
+-  let crcs = List.filter ~f:(fun (unit, _crc) -> keep unit) orig_crcs in
++  let crcs = List.filter ~f:(fun info -> keep (crc_name info)) (Array.to_list orig_crcs) in
+   let symbols =
+     Ocaml_compiler.Symtable.GlobalMap.filter
+       (function
+@@ -2690,7 +2696,7 @@ let from_exe
+         |> Array.of_list
+       in
+       (* Include linking information *)
+-      let sections = { symb = symbols; crcs; prim = primitives; dlpt = [] } in
++      let sections = { symb = symbols; crcs = Array.of_list crcs; prim = primitives; dlpt = [] } in
+       let gdata = Var.fresh () in
+       let need_gdata = ref false in
+       let infos =
+diff --git a/compiler/lib/parse_bytecode.mli b/compiler/lib/parse_bytecode.mli
+index 7bcc822..b34113b 100644
+--- a/compiler/lib/parse_bytecode.mli
++++ b/compiler/lib/parse_bytecode.mli
+@@ -91,5 +91,5 @@ val predefined_exceptions : unit -> Code.program * Unit_info.t
+ val link_info :
+      symbols:Ocaml_compiler.Symtable.GlobalMap.t
+   -> primitives:StringSet.t
+-  -> crcs:(string * Digest.t option) list
++  -> crcs:Import_info.t array
+   -> Code.program
+diff --git a/runtime/js/capsule.js b/runtime/js/capsule.js
+new file mode 100644
+index 0000000..0c02acc
+--- /dev/null
++++ b/runtime/js/capsule.js
+@@ -0,0 +1,14 @@
++//Provides: caml_capsule_mutex_new
++function caml_capsule_mutex_new () {
++  return 0;
++}
++
++//Provides: caml_capsule_mutex_lock
++function caml_capsule_mutex_lock () {
++  return 0;
++}
++
++//Provides: caml_capsule_mutex_unlock
++function caml_capsule_mutex_unlock () {
++  return 0;
++}
+diff --git a/runtime/js/dune b/runtime/js/dune
+index f31ffd1..7e76a14 100644
+--- a/runtime/js/dune
++++ b/runtime/js/dune
+@@ -4,6 +4,7 @@
+  (files
+   bigarray.js
+   bigstring.js
++  capsule.js
+   dynlink.js
+   fs.js
+   fs_fake.js
+diff --git a/runtime/js/float32.js b/runtime/js/float32.js
+index 0c60d3d..74bb433 100644
+--- a/runtime/js/float32.js
++++ b/runtime/js/float32.js
+@@ -12,6 +12,11 @@
+     by native programs and vice versa.
+ */
+
++//Provides: caml_is_boot_compiler
++function caml_is_boot_compiler(x) {
++  return 0;
++}
++
+ //Provides: caml_float_of_float32 const
+ function caml_float_of_float32(x) {
+     return x;
+diff --git a/runtime/js/toplevel.js b/runtime/js/toplevel.js
+index 2e4547e..adaffd3 100644
+--- a/runtime/js/toplevel.js
++++ b/runtime/js/toplevel.js
+@@ -94,7 +94,7 @@ function jsoo_toplevel_init_reloc(f) {
+ //Requires: caml_callback
+ //Requires: caml_string_of_uint8_array, caml_ba_to_typed_array
+ //Requires: jsoo_toplevel_compile, caml_failwith
+-//Version: >= 5.2
++//Version: >= 5.3
+ function caml_reify_bytecode(code, debug, _digest) {
+   if (!jsoo_toplevel_compile) {
+     caml_failwith("Toplevel not initialized (jsoo_toplevel_compile)");
+@@ -107,7 +107,7 @@ function caml_reify_bytecode(code, debug, _digest) {
+ //Requires: caml_callback
+ //Requires: caml_string_of_uint8_array, caml_uint8_array_of_bytes
+ //Requires: jsoo_toplevel_compile, caml_failwith
+-//Version: < 5.2
++//Version: < 5.3
+ function caml_reify_bytecode(code, debug, _digest) {
+   if (!jsoo_toplevel_compile) {
+     caml_failwith("Toplevel not initialized (jsoo_toplevel_compile)");
+diff --git a/toplevel/lib/jsooTop.ml b/toplevel/lib/jsooTop.ml
+index a1e5043..93c8ac0 100644
+--- a/toplevel/lib/jsooTop.ml
++++ b/toplevel/lib/jsooTop.ml
+@@ -65,25 +65,8 @@ let refill_lexbuf s p ppf buffer len =
+     p := !p + len'';
+     len''
+
+-[%%if ocaml_version < (4, 14, 0)]
+-let use ffp content =
+-  let fname, oc =
+-    Filename.open_temp_file ~mode:[ Open_binary ] "jsoo_toplevel" "fake_stdin"
+-  in
+-  output_string oc content;
+-  close_out oc;
+-  try
+-    let b = Toploop.use_silently ffp fname in
+-    Sys.remove fname;
+-    b
+-  with e ->
+-    Sys.remove fname;
+-    raise e
+-[%%endif]
+
+-[%%if ocaml_version >= (4, 14, 0)]
+ let use ffp content = Toploop.use_silently ffp (String content)
+-[%%endif]
+
+ let execute printval ?pp_code ?highlight_location pp_answer s =
+   let lb = Lexing.from_function (refill_lexbuf s (ref 0) pp_code) in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/dune.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/dune.patch
@@ -1,0 +1,38 @@
+diff --git a/compiler/lib/dune b/compiler/lib/dune
+index b03e41bd..23a20394 100644
+--- a/compiler/lib/dune
++++ b/compiler/lib/dune
+@@ -15,7 +15,7 @@
+  (flags
+   (:standard -w -7-37 -safe-string))
+  (preprocess
+-  (pps ppx_optcomp_light sedlex.ppx)))
++  (pps ppx_optcomp_light -no-check sedlex.ppx)))
+
+ (ocamllex annot_lexer)
+
+diff --git a/ppx/ppx_js/as-lib/dune b/ppx/ppx_js/as-lib/dune
+index f3d0f4c3..2cc128fd 100644
+--- a/ppx/ppx_js/as-lib/dune
++++ b/ppx/ppx_js/as-lib/dune
+@@ -2,7 +2,7 @@
+  (name ppx_js)
+  (public_name js_of_ocaml-ppx.as-lib)
+  (synopsis "Js_of_ocaml ppx")
+- (libraries compiler-libs.common ppxlib)
++ (libraries compiler-libs.common ppxlib ppxlib_jane)
+  (preprocess
+   (pps ppxlib.metaquot)))
+
+diff --git a/ppx/ppx_js/lib_internal/dune b/ppx/ppx_js/lib_internal/dune
+index d888f72b..aa92f071 100644
+--- a/ppx/ppx_js/lib_internal/dune
++++ b/ppx/ppx_js/lib_internal/dune
+@@ -1,6 +1,6 @@
+ (library
+  (name ppx_js_internal)
+- (libraries compiler-libs.common ppxlib)
++ (libraries compiler-libs.common ppxlib ppxlib_jane)
+  (kind ppx_rewriter)
+  (preprocess
+   (pps ppxlib.metaquot)))

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-5.2.0-compiler-changes.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-5.2.0-compiler-changes.patch
@@ -1,0 +1,561 @@
+--- a/compiler/lib/code.ml
++++ b/compiler/lib/code.ml
+@@ -333,6 +333,7 @@
+   | Int64 of Int64.t
+   | NativeInt of Int32.t (* Native int are 32bit on all known backend *)
+   | Tuple of int * constant array * array_or_not
++  | Null
+
+ module Constant = struct
+   type t = constant
+@@ -360,6 +361,7 @@
+     | Float_array a, Float_array b -> Some (Array.equal Float.ieee_equal a b)
+     | Float a, Float b -> Some (Float.ieee_equal a b)
+     | Float32 a, Float32 b -> Some (Float.ieee_equal a b)
++    | Null, Null -> Some true
+     | String _, NativeString _ | NativeString _, String _ -> None
+     | Int _, Float _ | Float _, Int _ -> None
+     | Int _, Float32 _ | Float32 _, Int _ -> None
+@@ -405,6 +407,7 @@
+     | ( (Int _ | Int32 _ | NativeInt _)
+       , (String _ | NativeString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ) ->
+         Some false
++    | (Null, _) | (_, Null) -> Some false
+     (* Note: the following cases should not occur when compiling to Javascript *)
+     | Int _, (Int32 _ | NativeInt _)
+     | Int32 _, (Int _ | NativeInt _)
+@@ -524,6 +527,7 @@
+               constant f a.(i)
+             done;
+             Format.fprintf f ")")
++    | Null -> Format.fprintf f "null"
+
+   let arg f a =
+     match a with
+@@ -885,7 +889,7 @@
+             | `Wasm -> true
+             | _ -> false)
+       | String _ | NativeString _ | Float _ | Float32 _ | Float_array _ | Int _ | Int64 _
+-      | Tuple (_, _, _) -> ()
++      | Tuple (_, _, _)  | Null -> ()
+     in
+     let check_prim_arg = function
+       | Pc c -> check_constant c
+--- a/compiler/lib/code.mli
++++ b/compiler/lib/code.mli
+@@ -179,6 +179,7 @@
+   | Int64 of Int64.t
+   | NativeInt of Int32.t  (** Only produced when compiling to WebAssembly. *)
+   | Tuple of int * constant array * array_or_not
++  | Null
+
+ module Constant : sig
+   type t = constant
+--- a/compiler/lib/eval.ml
++++ b/compiler/lib/eval.ml
+@@ -255,6 +255,7 @@
+   | Float32 _, Float _ | Float _, Float32 _ -> None
+   | NativeString a, NativeString b -> Some (Native_string.equal a b)
+   | String a, String b when Config.Flag.use_js_string () -> Some (String.equal a b)
++  | Null, Null -> Some true
+   | Int _, (Float _ | Float32 _) | (Float _ | Float32 _), Int _ -> None
+   (* All other values may be distinct objects and thus different by [caml_js_equals]. *)
+   | String _, _
+@@ -270,7 +271,9 @@
+   | NativeInt _, _
+   | _, NativeInt _
+   | Tuple _, _
+-  | _, Tuple _ -> None
++  | _, Tuple _
++  | Null, _
++  | _, Null -> None
+
+ let eval_instr ~target info ((x, loc) as i) =
+   match x with
+@@ -408,6 +411,7 @@
+     (fun x ->
+       match Flow.Info.def info x with
+       | Some (Constant (Int x)) -> if Targetint.is_zero x then Zero else Non_zero
++      | Some (Constant Null) -> Zero
+       | Some
+           (Constant
+             ( Int32 _
+--- a/compiler/lib/flow.ml
++++ b/compiler/lib/flow.ml
+@@ -371,11 +371,12 @@
+   | NativeInt _, NativeInt _, `Wasm ->
+       false (* [NativeInt]s are boxed in Wasm and are possibly different objects *)
+   | NativeInt _, NativeInt _, `JavaScript -> assert false
++  | Null, Null, _ -> true
+   (* All other values may be distinct objects and thus different by [caml_js_equals]. *)
+   | Int64 _, Int64 _, _ -> false
+   | Tuple _, Tuple _, _ -> false
+   | Float_array _, Float_array _, _ -> false
+-  | (Int _ | Float _ | Float32 _ | Int64 _ | Int32 _ | NativeInt _), _, _ -> false
++  | (Int _ | Float _ | Float32 _ | Int64 _ | Int32 _ | NativeInt _ | Null), _, _ -> false
+   | (String _ | NativeString _), _, _ -> false
+   | (Float_array _ | Tuple _), _, _ -> false
+
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -497,6 +497,7 @@
+   | Int i -> targetint i, instrs
+   | Int32 i | NativeInt i ->
+     J.ENum (J.Num.of_targetint (Targetint.of_int32_exn i)), instrs
++  | Null -> s_var "null", instrs
+
+ let constant ~ctx x level =
+   let expr, instr = constant_rec ~ctx x level [] in
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -45,9 +45,7 @@
+   | Const_mixed_block (tag, _, l) | Const_block (tag, l) ->
+       let l = Array.of_list (List.map l ~f:constant_of_const) in
+       Tuple (tag, l, Unknown)
+-  | Const_null ->
+-
+-    failwith "[Const_null] not supported in JavaScript yet."
++  | Const_null -> Null
+
+ let rec find_loc_in_summary ident' = function
+   | Env.Env_empty -> None
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -479,8 +479,14 @@
+
+   let ident_f32 = ident_of_custom (Obj.repr 0.s)
+
++  external is_null : Obj.t -> bool = "%is_null"
++
++  let is_null obj = is_null (Sys.opaque_identity obj)
++
+   let rec parse x =
+-    if Obj.is_block x
++    if is_null x then
++      Null
++    else if Obj.is_block x
+     then
+       let tag = Obj.tag x in
+       if tag = Obj.string_tag
+@@ -528,6 +534,7 @@
+     | Tuple _ -> false
+     | Int _ -> true
+     | Int32 _ | NativeInt _ -> false
++    | Null -> true
+ end
+
+ let const32 i = Constant (Int (Targetint.of_int32_exn i))
+@@ -2960,9 +2967,6 @@
+     }
+
+   let constant_of_const x = Ocaml_compiler.constant_of_const x
+-  [@@if ocaml_version < (5, 1, 0)]
+-
+-  let constant_of_const x = Constants.parse x [@@if ocaml_version >= (5, 1, 0)]
+
+   (* We currently rely on constants to be relocated before globals. *)
+   let step1 t compunit code =
+--- a/compiler/lib-wasm/gc_target.ml
++++ b/compiler/lib-wasm/gc_target.ml
+@@ -1068,6 +1068,13 @@
+     | NativeInt i ->
+         let* e = Memory.make_int32 ~kind:`Nativeint (return (W.Const (I32 i))) in
+         return (Const, e)
++    | Null ->
++      let* var =
++        register_import
++          ~name:"null"
++          (Global { mut = false; typ = Type.value })
++      in
++      return (Const, W.GlobalGet var)
+
+   let translate c =
+     let* const, c = translate_rec c in
+--- a/compiler/tests-ocaml/lib-atomic/test_atomic.ml
++++ b/compiler/tests-ocaml/lib-atomic/test_atomic.ml
+@@ -1,39 +1,39 @@
+ (* TEST *)
+
+-let r = Atomic.make 1
+-let () = assert (Atomic.get r = 1)
++let r = (Atomic.make [@ocaml.alert "-unsafe_multidomain"]) 1
++let () = assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r = 1)
+
+-let () = Atomic.set r 2
+-let () = assert (Atomic.get r = 2)
++let () = (Atomic.set [@ocaml.alert "-unsafe_multidomain"]) r 2
++let () = assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r = 2)
+
+-let () = assert (Atomic.exchange r 3 = 2)
++let () = assert ((Atomic.exchange [@ocaml.alert "-unsafe_multidomain"]) r 3 = 2)
+
+-let () = assert (Atomic.compare_and_set r 3 4 = true)
+-let () = assert (Atomic.get r = 4)
++let () = assert ((Atomic.compare_and_set [@ocaml.alert "-unsafe_multidomain"]) r 3 4 = true)
++let () = assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r = 4)
+
+-let () = assert (Atomic.compare_and_set r 3 (-4) = false)
+-let () = assert (Atomic.get r = 4 )
++let () = assert ((Atomic.compare_and_set [@ocaml.alert "-unsafe_multidomain"]) r 3 (-4) = false)
++let () = assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r = 4 )
+
+-let () = assert (Atomic.compare_and_set r 3 4 = false)
++let () = assert ((Atomic.compare_and_set [@ocaml.alert "-unsafe_multidomain"]) r 3 4 = false)
+
+ let () = assert (Atomic.fetch_and_add r 2 = 4)
+-let () = assert (Atomic.get r = 6)
++let () = assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r = 6)
+
+ let () = assert (Atomic.fetch_and_add r (-2) = 6)
+-let () = assert (Atomic.get r = 4)
++let () = assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r = 4)
+
+-let () = assert ((Atomic.incr r; Atomic.get r) = 5)
++let () = assert ((Atomic.incr r; (Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r) = 5)
+
+-let () = assert ((Atomic.decr r; Atomic.get r) = 4)
++let () = assert ((Atomic.decr r; (Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r) = 4)
+
+ let () =
+-  let r = Atomic.make 0 in
+-  let cur = Atomic.get r in
+-  ignore (Atomic.set r (cur + 1), Atomic.set r (cur - 1));
+-  assert (Atomic.get r <> cur)
++  let r = (Atomic.make [@ocaml.alert "-unsafe_multidomain"]) 0 in
++  let cur = (Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r in
++  ignore ((Atomic.set [@ocaml.alert "-unsafe_multidomain"]) r (cur + 1), (Atomic.set [@ocaml.alert "-unsafe_multidomain"]) r (cur - 1));
++  assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r <> cur)
+
+ let () =
+-  let r = Atomic.make 0 in
+-  let cur = Atomic.get r in
++  let r = (Atomic.make [@ocaml.alert "-unsafe_multidomain"]) 0 in
++  let cur = (Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r in
+   ignore (Atomic.incr r, Atomic.decr r);
+-  assert (Atomic.get r = cur)
++  assert ((Atomic.get [@ocaml.alert "-unsafe_multidomain"]) r = cur)
+--- a/lib/js_of_ocaml/js.ml
++++ b/lib/js_of_ocaml/js.ml
+@@ -813,7 +813,7 @@
+   if isNaN s then failwith "parseFloat" else s
+
+ let _ =
+-  Printexc.register_printer (fun e ->
++  (Printexc.register_printer [@ocaml.alert "-unsafe_multidomain"]) (fun e ->
+       if instanceof (Obj.magic e : < .. > t) error_constr
+       then
+         let e = Js_error.of_error (Obj.magic e : error t) in[]
+--- a/lib/runtime/jsoo_runtime.ml
++++ b/lib/runtime/jsoo_runtime.ml
+@@ -162,7 +162,7 @@
+
+   exception Exn of t
+
+-  let _ = Callback.register_exception "jsError" (Exn (Obj.magic [||]))
++  let _ = (Callback.register_exception [@ocaml.alert "-unsafe_multidomain"]) "jsError" (Exn (Obj.magic [||]))
+
+   let raise_ : t -> 'a = Js.js_expr "(function (exn) { throw exn })"
+
+--- a/runtime/js/domain.js
++++ b/runtime/js/domain.js
+@@ -36,6 +36,13 @@
+   return 0;
+ }
+
++//Provides: caml_atomic_compare_exchange
++function caml_atomic_compare_exchange(ref, o, n) {
++  var old = ref[1];
++  if (old === o) ref[1] = n;
++  return old;
++}
++
+ //Provides: caml_atomic_fetch_add
+ function caml_atomic_fetch_add(ref, i) {
+   var old = ref[1];
+@@ -43,6 +50,41 @@
+   return old;
+ }
+
++//Provides: caml_atomic_add
++function caml_atomic_add(ref, i) {
++  var old = ref[1];
++  ref[1] += i;
++  return 0;
++}
++
++//Provides: caml_atomic_sub
++function caml_atomic_sub(ref, i) {
++  var old = ref[1];
++  ref[1] -= i;
++  return 0;
++}
++
++//Provides: caml_atomic_land
++function caml_atomic_land(ref, i) {
++  var old = ref[1];
++  ref[1] &= i;
++  return 0;
++}
++
++//Provides: caml_atomic_lor
++function caml_atomic_lor(ref, i) {
++  var old = ref[1];
++  ref[1] |= i;
++  return 0;
++}
++
++//Provides: caml_atomic_lxor
++function caml_atomic_lxor(ref, i) {
++  var old = ref[1];
++  ref[1] ^= i;
++  return 0;
++}
++
+ //Provides: caml_atomic_exchange
+ function caml_atomic_exchange(ref, v) {
+   var r = ref[1];
+--- a/runtime/js/marshal.js
++++ b/runtime/js/marshal.js
+@@ -44,6 +44,7 @@
+   CODE_CUSTOM: 0x12,
+   CODE_CUSTOM_LEN: 0x18,
+   CODE_CUSTOM_FIXED: 0x19,
++  CODE_NULL: 0x1f
+ };
+
+ //Provides: UInt8ArrayReader
+@@ -539,6 +540,8 @@
+             }
+             if (intern_obj_table) intern_obj_table[obj_counter++] = v;
+             return v;
++          case 0x1f: //cst.CODE_NULL:
++            return null;
+           default:
+             caml_failwith("input_value: ill-formed message");
+         }
+@@ -742,7 +745,9 @@
+     }
+
+     function extern_rec(v) {
+-      if (v.caml_custom) {
++      if (v === null) {
++        writer.write(8, 0x1f /*cst.CODE_NULL*/);
++      } else if (v.caml_custom) {
+         if (memo(v)) return;
+         var name = v.caml_custom;
+         var ops = caml_custom_ops[name];
+--- a/runtime/js/obj.js
++++ b/runtime/js/obj.js
+@@ -46,7 +46,8 @@
+ //Provides: caml_obj_tag
+ //Requires: caml_is_ml_bytes, caml_is_ml_string
+ function caml_obj_tag(x) {
+-  if (Array.isArray(x) && x[0] === x[0] >>> 0) return x[0];
++  if (x === null) return 1010;
++  else if (Array.isArray(x) && x[0] === x[0] >>> 0) return x[0];
+   else if (caml_is_ml_bytes(x)) return 252;
+   else if (caml_is_ml_string(x)) return 252;
+   else if (x instanceof Function || typeof x == "function") return 247;
+@@ -272,3 +273,16 @@
+ function caml_custom_identifier(o) {
+   return caml_string_of_jsstring(o.caml_custom);
+ }
++
++//Provides: caml_int_as_pointer
++//Requires: caml_failwith
++function caml_int_as_pointer(i) {
++  // Special-case null pointers for [or_null].
++  if (i == 0) return null;
++  caml_failwith("%int_as_pointer is not supported in javascript.");
++}
++
++//Provides: caml_is_null
++function caml_is_null(o) {
++  return o === null;
++}
+--- a/runtime/wasm/domain.wat
++++ b/runtime/wasm/domain.wat
+@@ -34,6 +34,21 @@
+          (else
+             (ref.i31 (i32.const 0)))))
+
++   (func (export "caml_atomic_compare_exchange")
++      (param $ref (ref eq)) (param $o (ref eq)) (param $n (ref eq))
++      (result (ref eq))
++      (local $b (ref $block))
++      (local $old (ref eq))
++      (local.set $b (ref.cast (ref $block) (local.get $ref)))
++      (local.set $old (array.get $block (local.get $b) (i32.const 1)))
++      (if (result (ref eq))
++         (ref.eq (local.get $old) (local.get $o))
++         (then
++            (array.set $block (local.get $b) (i32.const 1) (local.get $n))
++            (local.get $old))
++         (else
++            (local.get $old))))
++
+    (func (export "caml_atomic_load") (param (ref eq)) (result (ref eq))
+       (array.get $block (ref.cast (ref $block) (local.get 0)) (i32.const 1)))
+
+@@ -48,6 +63,61 @@
+                            (i31.get_s (ref.cast (ref i31) (local.get $i))))))
+       (local.get $old))
+
++   (func (export "caml_atomic_add")
++      (param $ref (ref eq)) (param $i (ref eq)) (result (ref eq))
++      (local $b (ref $block))
++      (local $old (ref eq))
++      (local.set $b (ref.cast (ref $block) (local.get $ref)))
++      (local.set $old (array.get $block (local.get $b) (i32.const 1)))
++      (array.set $block (local.get $b) (i32.const 1)
++         (ref.i31 (i32.add (i31.get_s (ref.cast (ref i31) (local.get $old)))
++                           (i31.get_s (ref.cast (ref i31) (local.get $i))))))
++      (ref.i31 (i32.const 0)))
++
++   (func (export "caml_atomic_sub")
++      (param $ref (ref eq)) (param $i (ref eq)) (result (ref eq))
++      (local $b (ref $block))
++      (local $old (ref eq))
++      (local.set $b (ref.cast (ref $block) (local.get $ref)))
++      (local.set $old (array.get $block (local.get $b) (i32.const 1)))
++      (array.set $block (local.get $b) (i32.const 1)
++         (ref.i31 (i32.sub (i31.get_s (ref.cast (ref i31) (local.get $old)))
++                           (i31.get_s (ref.cast (ref i31) (local.get $i))))))
++      (ref.i31 (i32.const 0)))
++
++   (func (export "caml_atomic_land")
++      (param $ref (ref eq)) (param $i (ref eq)) (result (ref eq))
++      (local $b (ref $block))
++      (local $old (ref eq))
++      (local.set $b (ref.cast (ref $block) (local.get $ref)))
++      (local.set $old (array.get $block (local.get $b) (i32.const 1)))
++      (array.set $block (local.get $b) (i32.const 1)
++         (ref.i31 (i32.and (i31.get_s (ref.cast (ref i31) (local.get $old)))
++                           (i31.get_s (ref.cast (ref i31) (local.get $i))))))
++      (ref.i31 (i32.const 0)))
++
++   (func (export "caml_atomic_lor")
++      (param $ref (ref eq)) (param $i (ref eq)) (result (ref eq))
++      (local $b (ref $block))
++      (local $old (ref eq))
++      (local.set $b (ref.cast (ref $block) (local.get $ref)))
++      (local.set $old (array.get $block (local.get $b) (i32.const 1)))
++      (array.set $block (local.get $b) (i32.const 1)
++         (ref.i31 (i32.or (i31.get_s (ref.cast (ref i31) (local.get $old)))
++                           (i31.get_s (ref.cast (ref i31) (local.get $i))))))
++      (ref.i31 (i32.const 0)))
++
++   (func (export "caml_atomic_lxor")
++      (param $ref (ref eq)) (param $i (ref eq)) (result (ref eq))
++      (local $b (ref $block))
++      (local $old (ref eq))
++      (local.set $b (ref.cast (ref $block) (local.get $ref)))
++      (local.set $old (array.get $block (local.get $b) (i32.const 1)))
++      (array.set $block (local.get $b) (i32.const 1)
++         (ref.i31 (i32.xor (i31.get_s (ref.cast (ref i31) (local.get $old)))
++                           (i31.get_s (ref.cast (ref i31) (local.get $i))))))
++      (ref.i31 (i32.const 0)))
++
+    (func (export "caml_atomic_exchange")
+       (param $ref (ref eq)) (param $v (ref eq)) (result (ref eq))
+       (local $b (ref $block))
+--- a/runtime/wasm/obj.wat
++++ b/runtime/wasm/obj.wat
+@@ -86,6 +86,9 @@
+             (field (ref $function_2))
+             (field (mut (ref null $cps_closure))))))
+
++   (type $null (struct))
++   (global $null (export "null") (ref eq) (struct.new $null))
++
+    (global $forcing_tag i32 (i32.const 244))
+    (global $cont_tag (export "cont_tag") i32 (i32.const 245))
+    (global $lazy_tag (export "lazy_tag") i32 (i32.const 246))
+@@ -239,6 +242,8 @@
+       (local.get $res))
+
+    (func (export "caml_obj_tag") (param $v (ref eq)) (result (ref eq))
++      (if (ref.eq (local.get $v) (global.get $null))
++         (then (return (ref.i31 (i32.const 1010)))))
+       (if (ref.test (ref i31) (local.get $v))
+          (then (return (ref.i31 (i32.const 1000)))))
+       (drop (block $not_block (result (ref eq))
+@@ -487,4 +492,20 @@
+                (array.new_fixed $block 3 (ref.i31 (i32.const 0))
+                  (local.get $x) (local.get $y))
+                (ref.as_non_null (global.get $caml_trampoline_ref))))))
+-)
++
++   (func (export "caml_is_null") (param $x (ref eq)) (result (ref eq))
++      (if (result (ref eq)) (ref.eq (local.get $x) (global.get $null))
++        (then (ref.i31 (i32.const 1)))
++        (else (ref.i31 (i32.const 0)))))
++
++   (data $int_as_pointer_not_implemented "caml_int_as_pointer is not supported")
++
++   (func (export "caml_int_as_pointer") (param $x (ref eq)) (result (ref eq))
++      (if (result (ref eq))
++         (i32.eq (i31.get_s (ref.cast (ref i31) (local.get $x))) (i32.const 0))
++         (then (global.get $null))
++         (else
++          (call $caml_failwith
++            (array.new_data $bytes $int_as_pointer_not_implemented
++              (i32.const 0) (i32.const 35)))
++           (ref.i31 (i32.const 0))))))
+--- a/runtime/js/compare.js
++++ b/runtime/js/compare.js
+@@ -18,6 +18,7 @@
+ //Provides: caml_compare_val_tag
+ //Requires: caml_is_ml_string, caml_is_ml_bytes
+ function caml_compare_val_tag(a) {
++  if (a === null) return 1010; // null_tag
+   if (typeof a === "number")
+     return 1000; // int_tag (we use it for all numbers)
+   else if (caml_is_ml_bytes(a))
+@@ -93,6 +94,13 @@
+
+       // tags are different
+       if (tag_a !== tag_b) {
++        if (tag_a === 1010) {
++          // Null is less than anything else
++          return -1;
++        }
++        if (tag_b === 1010) {
++          return 1;
++        }
+         if (tag_a === 1000) {
+           if (tag_b === 1255) {
+             //immediate can compare against custom
+@@ -193,6 +201,8 @@
+             if (!Number.isNaN(b)) return -1;
+           }
+           break;
++        case 1010: // Null pointer
++          return 0;
+         case 1001: // The rest
+           // Here we can be in the following cases:
+           // 1. JavaScript primitive types
+--- a/runtime/wasm/compare.wat
++++ b/runtime/wasm/compare.wat
+@@ -25,6 +25,7 @@
+       (func $caml_obj_tag (param (ref eq)) (result (ref eq))))
+    (import "obj" "caml_is_closure"
+       (func $caml_is_closure (param (ref eq)) (result i32)))
++   (import "obj" "null" (global $null (ref eq)))
+    (import "fail" "caml_invalid_argument"
+       (func $caml_invalid_argument (param (ref eq))))
+    (import "effect" "caml_is_continuation"
+@@ -238,6 +239,13 @@
+             (if (local.get $total)
+                (then
+                   (br_if $next_item (ref.eq (local.get $v1) (local.get $v2)))))
++            (if (ref.eq (local.get $v1) (global.get $null))
++               (then
++                  (if (ref.eq (local.get $v2) (global.get $null))
++                     (then (return (i32.const 0)))
++                     (else (return (i32.const -1))))))
++            (if (ref.eq (local.get $v2) (global.get $null))
++               (then (return (i32.const 1))))
+             (drop (block $v1_is_not_int (result (ref eq))
+                (local.set $i1
+                   (br_on_cast_fail $v1_is_not_int (ref eq) (ref i31)

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-5.3-tests-runtime.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-5.3-tests-runtime.patch
@@ -1,0 +1,84 @@
+--- a/compiler/tests-ocaml/lib-list/test.ml
++++ b/compiler/tests-ocaml/lib-list/test.ml
+@@ -64,7 +64,7 @@
+   let hello = ['H';'e';'l';'l';'o'] in
+   let world = ['W';'o';'r';'l';'d';'!'] in
+   let hello_world = hello @ [' '] @ world in
+-  assert (List.take 5 hello_world = hello);
++  (* assert (List.take 5 hello_world = hello);
+   assert (List.take 3 [1; 2; 3; 4; 5] = [1; 2; 3]);
+   assert (List.take 3 [1; 2] = [1; 2]);
+   assert (List.take 3 [] = []);
+@@ -83,7 +83,7 @@
+   assert (List.drop_while (fun x -> x < 3) [1; 2; 3; 4; 5; 1; 2; 3]
+           = [3; 4; 5; 1; 2; 3]);
+   assert (List.drop_while (fun x -> x < 9) [1; 2; 3] = []);
+-  assert (List.drop_while (fun x -> x < 0) [1; 2; 3] = [1; 2; 3]);
++  assert (List.drop_while (fun x -> x < 0) [1; 2; 3] = [1; 2; 3]); *)
+   assert (List.partition is_even [1; 2; 3; 4; 5]
+           = ([2; 4], [1; 3; 5]));
+   assert (List.partition_map string_of_even_or_int [1; 2; 3; 4; 5]
+--- a/compiler/tests-ocaml/lib-queue/test.ml
++++ b/compiler/tests-ocaml/lib-queue/test.ml
+@@ -137,11 +137,11 @@
+   assert (Q.length q2 = 8); assert (Q.to_list q2 = [5; 6; 7; 8; 1; 2; 3; 4]);
+ ;;
+
+-let () =
++(* let () =
+   let q = Q.create () in
+   Q.add 1 q; Q.drop q; assert (does_raise Q.drop q);
+   Q.add 2 q; Q.drop q; assert (does_raise Q.drop q);
+   assert (Q.length q = 0);
+-;;
++;; *)
+
+ let () = print_endline "OK"
+--- a/compiler/tests-ocaml/lib-hashtbl/hfun.expected
++++ b/compiler/tests-ocaml/lib-hashtbl/hfun.expected
+@@ -8,19 +8,19 @@
+ 2^30-1		23c392d0
+ -2^30		0c66fde3
+ -- Floats:
+-+0.0		0f478b8c
+--0.0		0f478b8c
+++0.0		07be548a
++-0.0		07be548a
+ +infty		23ea56fb
+ -infty		059f7872
+ NaN		3228858d
+ NaN#2		3228858d
+ NaN#3		3228858d
+ -- Native integers:
+-0		3f19274a
++0		07be548a
+ -1		3653e015
+-42		3e33aef8
+-2^30-1		3711bf46
+--2^30		2e71f39c
++42		1792870b
++2^30-1		23c392d0
++-2^30		0c66fde3
+ -- Lists:
+ [0..10]		0ade0fc9
+ [0..12]		0ade0fc9
+--- a/compiler/tests-ocaml/lib-uchar/test.ml
++++ b/compiler/tests-ocaml/lib-uchar/test.ml
+@@ -74,7 +74,7 @@
+ let test_hash () =
+   let f u =
+     assert (Hashtbl.hash u = Uchar.hash u);
+-    assert (Hashtbl.seeded_hash 42 u = Uchar.seeded_hash 42 u)
++    (* assert (Hashtbl.seeded_hash 42 u = Uchar.seeded_hash 42 u) *)
+   in
+   List.iter (Fun.compose f Uchar.of_int)
+     [0x0000; 0x002D; 0x00E9; 0x062D; 0x2014; 0x1F349]
+@@ -117,7 +117,7 @@
+   test_to_char ();
+   test_equal ();
+   test_compare ();
+-  test_hash ();
++  (* test_hash (); *)
+   test_utf_decode ();
+   test_utf_x_byte_length ();
+   ()

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-Env_value-arguments.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-Env_value-arguments.patch
@@ -1,0 +1,14 @@
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -41,9 +41,9 @@
+
+ let rec find_loc_in_summary ident' = function
+   | Env.Env_empty -> None
+-  | Env.Env_value (_summary, ident, description) when Poly.(ident = ident') ->
++  | Env.Env_value (_summary, ident, description, _) when Poly.(ident = ident') ->
+       Some description.Types.val_loc
+-  | Env.Env_value (summary, _, _)
++  | Env.Env_value (summary, _, _, _)
+   | Env.Env_type (summary, _, _)
+   | Env.Env_extension (summary, _, _)
+   | Env.Env_module (summary, _, _, _)

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-add-unboxed-and-float-block.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-add-unboxed-and-float-block.patch
@@ -1,0 +1,30 @@
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -31,22 +31,21 @@
+   let open Lambda in
+-  let open Asttypes in
+   match c with
+   | Const_base (Const_int i) -> Int (Targetint.of_int_warning_on_overflow i)
+   | Const_base (Const_char c) -> Int (Targetint.of_int_exn (Char.code c))
+   | ((Const_base (Const_string (s, _))) [@if ocaml_version < (4, 11, 0)])
+   | ((Const_base (Const_string (s, _, _))) [@if ocaml_version >= (4, 11, 0)]) -> String s
+-  | Const_base (Const_float s) -> Float (float_of_string s)
++  | Const_base (Const_float32 s | Const_unboxed_float32 s | Const_float s | Const_unboxed_float s) -> Float (float_of_string s)
+-  | Const_base (Const_int32 i) -> (
++  | Const_base (Const_int32 i | Const_unboxed_int32 i) -> (
+       match Config.target () with
+       | `JavaScript -> Int (Targetint.of_int32_warning_on_overflow i)
+       | `Wasm -> Int32 i)
+-  | Const_base (Const_int64 i) -> Int64 i
++  | Const_base (Const_int64 i | Const_unboxed_int64 i) -> Int64 i
+-  | Const_base (Const_nativeint i) -> (
++  | Const_base (Const_nativeint i | Const_unboxed_nativeint i) -> (
+       match Config.target () with
+       | `JavaScript -> Int (Targetint.of_nativeint_warning_on_overflow i)
+       | `Wasm -> NativeInt (Int32.of_nativeint_warning_on_overflow i))
+   | Const_immstring s -> String s
+-  | Const_float_array sl ->
++  | Const_float_array sl | Const_float_block sl ->
+       let l = List.map ~f:(fun f -> float_of_string f) sl in
+       Float_array (Array.of_list l)
+   | ((Const_pointer i) [@if ocaml_version < (4, 12, 0)]) ->

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-bigstring-reader-bugfix.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-bigstring-reader-bugfix.patch
@@ -1,0 +1,81 @@
+--- a/runtime/js/marshal.js
++++ b/runtime/js/marshal.js
+@@ -177,78 +177,6 @@
+   }
+ }
+
+-//Provides: BigStringReader
+-//Requires: caml_string_of_uint8_array, caml_ba_get_1
+-class BigStringReader {
+-  constructor(bs, i) {
+-    this.s = bs;
+-    this.i = i;
+-  }
+-
+-  read8u() {
+-    return caml_ba_get_1(this.s, this.i++);
+-  }
+-
+-  read8s() {
+-    return (caml_ba_get_1(this.s, this.i++) << 24) >> 24;
+-  }
+-
+-  read16u() {
+-    var s = this.s,
+-      i = this.i;
+-    this.i = i + 2;
+-    return (caml_ba_get_1(s, i) << 8) | caml_ba_get_1(s, i + 1);
+-  }
+-
+-  read16s() {
+-    var s = this.s,
+-      i = this.i;
+-    this.i = i + 2;
+-    return ((caml_ba_get_1(s, i) << 24) >> 16) | caml_ba_get_1(s, i + 1);
+-  }
+-
+-  read32u() {
+-    var s = this.s,
+-      i = this.i;
+-    this.i = i + 4;
+-    return (
+-      ((caml_ba_get_1(s, i) << 24) |
+-        (caml_ba_get_1(s, i + 1) << 16) |
+-        (caml_ba_get_1(s, i + 2) << 8) |
+-        caml_ba_get_1(s, i + 3)) >>>
+-      0
+-    );
+-  }
+-
+-  read32s() {
+-    var s = this.s,
+-      i = this.i;
+-    this.i = i + 4;
+-    return (
+-      (caml_ba_get_1(s, i) << 24) |
+-      (caml_ba_get_1(s, i + 1) << 16) |
+-      (caml_ba_get_1(s, i + 2) << 8) |
+-      caml_ba_get_1(s, i + 3)
+-    );
+-  }
+-
+-  readstr(len) {
+-    var i = this.i;
+-    var offset = this.offset(i);
+-    this.i = i + len;
+-    return caml_string_of_uint8_array(
+-      this.s.data.subarray(offset, offset + len),
+-    );
+-  }
+-
+-  readuint8array(len) {
+-    var i = this.i;
+-    var offset = this.offset(i);
+-    this.i = i + len;
+-    return this.s.data.subarray(offset, offset + len);
+-  }
+-}
+-
+ //Provides: caml_float_of_bytes
+ //Requires: caml_int64_float_of_bits, caml_int64_of_bytes
+ function caml_float_of_bytes(a) {

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_array_append.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_array_append.patch
@@ -1,0 +1,27 @@
+--- a/runtime/js/array.js
++++ b/runtime/js/array.js
+@@ -54,6 +54,12 @@
+   return a;
+ }
+
++//Provides: caml_array_append_local mutable
++//Requires: caml_array_append
++function caml_array_append_local(a1, a2) {
++  return caml_array_append(a1, a2);
++}
++
+ //Provides: caml_floatarray_append mutable
+ //Requires: caml_array_append
+ //Version: >= 5.3
+--- a/runtime/wasm/array.wat
++++ b/runtime/wasm/array.wat
+@@ -143,7 +143,8 @@
+          (local.get $len))
+       (local.get $a'))
+
+-   (func (export "caml_array_append")
++   (export "caml_array_append_local" (func $caml_array_append))
++   (func $caml_array_append (export "caml_array_append")
+       (param $va1 (ref eq)) (param $va2 (ref eq)) (result (ref eq))
+       (local $a1 (ref $block)) (local $a2 (ref $block)) (local $a (ref $block))
+       (local $fa1 (ref $float_array)) (local $fa2 (ref $float_array))

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_bigstring_strncmp.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_bigstring_strncmp.patch
@@ -1,0 +1,51 @@
+--- a/runtime/wasm/bigstring.wat
++++ b/runtime/wasm/bigstring.wat
+@@ -225,6 +225,48 @@
+                (br $loop))))
+       (ref.i31 (i32.const -1)))
+ 
++   (func (export "caml_bigstring_strncmp")
++      (param $vs1 (ref eq))
++      (param $vpos1 (ref eq))
++      (param $vs2 (ref eq))
++      (param $vpos2 (ref eq))
++      (param $vlen (ref eq))
++      (result (ref eq))
++
++      (local $d1 (ref extern))
++      (local $d2 (ref extern))
++      (local $pos1 i32)
++      (local $pos2 i32)
++      (local $len i32)
++
++      (local $i i32)
++      (local $c1 i32)
++      (local $c2 i32)
++
++      (local.set $d1 (call $caml_ba_get_data (local.get $vs1)))
++      (local.set $d2 (call $caml_ba_get_data (local.get $vs2)))
++      (local.set $pos1 (i31.get_s (ref.cast (ref i31) (local.get $vpos1))))
++      (local.set $pos2 (i31.get_s (ref.cast (ref i31) (local.get $vpos2))))
++      (local.set $len (i31.get_s (ref.cast (ref i31) (local.get $vlen))))
++      (loop $loop
++         (if (i32.lt_u (local.get $i) (local.get $len))
++            (then
++               (local.set $c1
++                  (call $ta_get_ui8 (local.get $d1)
++                     (i32.add (local.get $pos1) (local.get $i))))
++               (local.set $c2
++                  (call $ta_get_ui8 (local.get $d2)
++                     (i32.add (local.get $pos2) (local.get $i))))
++               (local.set $i (i32.add (local.get $i) (i32.const 1)))
++               (if (i32.lt_u (local.get $c1) (local.get $c2))
++                  (then (return (ref.i31 (i32.const -1)))))
++               (if (i32.gt_u (local.get $c1) (local.get $c2))
++                  (then (return (ref.i31 (i32.const 1)))))
++               (if (i32.eq (local.get $c1) (i32.const 0))
++                  (then (return (ref.i31 (i32.const 0)))))
++               (br $loop))))
++      (ref.i31 (i32.const 0)))
++
+    (export "caml_bigstring_blit_string_to_ba"
+       (func $caml_bigstring_blit_bytes_to_ba))
+    (func $caml_bigstring_blit_bytes_to_ba

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_hash_exn.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_hash_exn.patch
@@ -1,0 +1,25 @@
+--- a/runtime/js/hash.js	Sun Apr 28 23:53:39 2024 -0400
++++ b/runtime/js/hash.js	Tue Apr 30 11:19:08 2024 +0800
+@@ -185,5 +185,5 @@
+ }
+
+-//Provides: caml_hash mutable
++//Provides: caml_hash_exn mutable
+ //Requires: caml_is_ml_string, caml_is_ml_bytes
+ //Requires: caml_hash_mix_int, caml_hash_mix_final
+@@ -191,5 +191,5 @@
+ //Requires: caml_hash_mix_jsbytes
+ //Requires: caml_is_continuation_tag
+-function caml_hash(count, limit, seed, obj) {
++function caml_hash_exn(count, limit, seed, obj) {
+   var queue, rd, wr, sz, num, h, v, i, len;
+   sz = limit;
+--- a/runtime/wasm/hash.wat	Sun Apr 28 23:53:39 2024 -0400
++++ b/runtime/wasm/hash.wat	Tue Apr 30 11:19:08 2024 +0800
+@@ -147,5 +147,5 @@
+       (array.new $block (ref.i31 (i32.const 0)) (global.get $HASH_QUEUE_SIZE)))
+
+-   (func (export "caml_hash")
++   (func (export "caml_hash_exn")
+       (param $count (ref eq)) (param $limit (ref eq)) (param $seed (ref eq))
+       (param $obj (ref eq)) (result (ref eq))

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_provides_sub_local.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-caml_provides_sub_local.patch
@@ -1,0 +1,26 @@
+--- a/runtime/js/array.js
++++ b/runtime/js/array.js
+@@ -27,5 +27,11 @@
+   return a2;
+ }
++
++//Provides: caml_array_sub_local mutable
++//Requires: caml_array_sub
++function caml_array_sub_local(a, i, len) {
++  return caml_array_sub(a, i, len);
++}
+
+ //Provides: caml_array_append mutable
+ function caml_array_append(a1, a2) {
+--- a/runtime/wasm/array.wat
++++ b/runtime/wasm/array.wat
+@@ -61,7 +61,8 @@
+          (struct.get $float 0 (ref.cast (ref $float) (local.get $v))))
+       (ref.i31 (i32.const 0)))
+
+-   (func (export "caml_array_sub")
++   (export "caml_array_sub_local" (func $caml_array_sub))
++   (func $caml_array_sub (export "caml_array_sub")
+       (param $a (ref eq)) (param $i (ref eq)) (param $vlen (ref eq))
+       (result (ref eq))
+       (local $a1 (ref $block)) (local $a2 (ref $block)) (local $len i32)

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-compilation_unit-name.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-compilation_unit-name.patch
@@ -1,0 +1,116 @@
+--- a/compiler/bin-js_of_ocaml/compile.ml
++++ b/compiler/bin-js_of_ocaml/compile.ml
+@@ -235,7 +235,7 @@
+     sm
+   in
+   let output_partial
+-      (cmo : Cmo_format.compilation_unit)
++      (cmo : Cmo_format.compilation_unit_descr)
+       ~standalone
+       ~source_map
+       code
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -213,16 +213,16 @@
+ end
+
+ module Cmo_format = struct
+-  type t = Cmo_format.compilation_unit
++  type t = Cmo_format.compilation_unit_descr
+
+-  let name (t : t) = t.cu_name [@@if ocaml_version < (5, 2, 0)]
++  let name (t : t) = t.cu_name |> Compilation_unit.name_as_string [@@if ocaml_version < (5, 2, 0)]
+
+   let name (t : t) =
+     let (Compunit name) = t.cu_name in
+     name
+   [@@if ocaml_version >= (5, 2, 0)]
+
+-  let requires (t : t) = List.map ~f:Ident.name t.cu_required_globals
++  let requires (t : t) = List.map ~f:Compilation_unit.name_as_string t.cu_required_globals
+   [@@if ocaml_version < (5, 2, 0)]
+
+   let requires (t : t) = List.map t.cu_required_compunits ~f:(fun (Compunit u) -> u)
+--- a/compiler/lib/ocaml_compiler.mli
++++ b/compiler/lib/ocaml_compiler.mli
+@@ -55,7 +55,7 @@
+ end
+
+ module Cmo_format : sig
+-  type t = Cmo_format.compilation_unit
++  type t = Cmo_format.compilation_unit_descr
+
+   val name : t -> string
+
+@@ -65,5 +65,5 @@
+
+   val force_link : t -> bool
+
+-  val imports : t -> (string * string option) list
++  val imports : t -> Import_info.t array
+ end
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -2633,8 +2633,10 @@
+
+   let read_crcs toc ic =
+     ignore (seek_section toc ic "CRCS");
+-    let orig_crcs : (string * Digest.t option) list = input_value ic in
+-    orig_crcs
++    let orig_crcs : Import_info.t array = input_value ic in
++    List.map (Array.to_list orig_crcs) ~f:(fun import ->
++      Import_info.name import |> Compilation_unit.Name.to_string,
++      Import_info.crc import)
+
+   let read_prim toc ic =
+     let prim_size = seek_section toc ic "PRIM" in
+@@ -3096,7 +3098,7 @@
+           then raise Magic_number.(Bad_magic_version magic);
+           let compunit_pos = input_binary_int ic in
+           seek_in ic compunit_pos;
+-          let compunit : Cmo_format.compilation_unit = input_value ic in
++          let compunit : Cmo_format.compilation_unit_descr = input_value ic in
+           `Cmo compunit
+       | `Cma ->
+           if Config.Flag.check_magic ()
+--- a/compiler/lib/parse_bytecode.mli
++++ b/compiler/lib/parse_bytecode.mli
+@@ -65,7 +65,7 @@
+      ?includes:string list
+   -> ?include_cmis:bool
+   -> ?debug:bool
+-  -> Cmo_format.compilation_unit
++  -> Cmo_format.compilation_unit_descr
+   -> in_channel
+   -> one
+
+@@ -79,7 +79,7 @@
+
+ val from_channel :
+      in_channel
+-  -> [ `Cmo of Cmo_format.compilation_unit | `Cma of Cmo_format.library | `Exe ]
++  -> [ `Cmo of Cmo_format.compilation_unit_descr | `Cma of Cmo_format.library | `Exe ]
+
+ val from_string :
+      prims:string array
+--- a/compiler/lib/unit_info.ml
++++ b/compiler/lib/unit_info.ml
+@@ -37,7 +37,7 @@
+   ; effects_without_cps = false
+   }
+
+-let of_cmo (cmo : Cmo_format.compilation_unit) =
++let of_cmo (cmo : Cmo_format.compilation_unit_descr) =
+   let open Ocaml_compiler in
+   let provides = StringSet.singleton (Cmo_format.name cmo) in
+   let requires = StringSet.of_list (Cmo_format.requires cmo) in
+--- a/compiler/lib/unit_info.mli
++++ b/compiler/lib/unit_info.mli
+@@ -26,6 +26,6 @@
+   ; effects_without_cps : bool
+   }
+
+-val of_cmo : Cmo_format.compilation_unit -> t
++val of_cmo : Cmo_format.compilation_unit_descr -> t
+
+ val union : t -> t -> t

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-dune.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-dune.patch
@@ -1,0 +1,38 @@
+diff --git a/compiler/lib/dune b/compiler/lib/dune
+index b03e41bd..23a20394 100644
+--- a/compiler/lib/dune
++++ b/compiler/lib/dune
+@@ -15,7 +15,7 @@
+  (flags
+   (:standard -w -7-37 -safe-string))
+  (preprocess
+-  (pps ppx_optcomp_light sedlex.ppx)))
++  (pps ppx_optcomp_light -no-check sedlex.ppx)))
+
+ (ocamllex annot_lexer)
+
+diff --git a/ppx/ppx_js/as-lib/dune b/ppx/ppx_js/as-lib/dune
+index f3d0f4c3..2cc128fd 100644
+--- a/ppx/ppx_js/as-lib/dune
++++ b/ppx/ppx_js/as-lib/dune
+@@ -2,7 +2,7 @@
+  (name ppx_js)
+  (public_name js_of_ocaml-ppx.as-lib)
+  (synopsis "Js_of_ocaml ppx")
+- (libraries compiler-libs.common ppxlib)
++ (libraries compiler-libs.common ppxlib ppxlib_jane)
+  (preprocess
+   (pps ppxlib.metaquot)))
+
+diff --git a/ppx/ppx_js/lib_internal/dune b/ppx/ppx_js/lib_internal/dune
+index d888f72b..aa92f071 100644
+--- a/ppx/ppx_js/lib_internal/dune
++++ b/ppx/ppx_js/lib_internal/dune
+@@ -1,6 +1,6 @@
+ (library
+  (name ppx_js_internal)
+- (libraries compiler-libs.common ppxlib)
++ (libraries compiler-libs.common ppxlib ppxlib_jane)
+  (kind ppx_rewriter)
+  (preprocess
+   (pps ppxlib.metaquot)))

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-empty-sourcemap.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-empty-sourcemap.patch
@@ -1,0 +1,311 @@
+--- a/compiler/bin-js_of_ocaml/cmd_arg.ml
++++ b/compiler/bin-js_of_ocaml/cmd_arg.ml
+@@ -54,7 +54,7 @@
+   { common : Jsoo_cmdline.Arg.t
+   ; (* compile option *)
+     profile : Driver.profile option
+-  ; source_map : (string option * Source_map.Standard.t) option
++  ; source_map : Source_map.Spec.t option
+   ; runtime_files : string list
+   ; no_runtime : bool
+   ; include_runtime : bool
+@@ -158,6 +158,12 @@
+     let doc = "Do not inline sources in source map." in
+     Arg.(value & flag & info [ "source-map-no-source" ] ~doc)
+   in
++  let sourcemap_empty =
++    let doc =
++      "Always generate empty source maps."
++    in
++    Arg.(value & flag & info [ "empty-sourcemap"; "empty-source-map" ] ~doc)
++  in
+   let sourcemap_root =
+     let doc = "root dir for source map." in
+     Arg.(value & opt (some string) None & info [ "source-map-root" ] ~doc)
+@@ -296,6 +302,7 @@
+       sourcemap
+       sourcemap_inline_in_js
+       sourcemap_don't_inline_content
++      sourcemap_empty
+       sourcemap_root
+       target_env
+       output_file
+@@ -323,19 +330,26 @@
+     in
+     let source_map =
+       if (not no_sourcemap) && (sourcemap || sourcemap_inline_in_js)
+-      then
++      then (
+         let file, sm_output_file =
+           match output_file with
+           | `Name file, _ when sourcemap_inline_in_js -> Some file, None
+           | `Name file, _ -> Some file, Some (chop_extension file ^ ".map")
+           | `Stdout, _ -> None, None
+         in
+-        Some
+-          ( sm_output_file
+-          , { (Source_map.Standard.empty ~inline_source_content) with
+-              file
+-            ; sourceroot = sourcemap_root
+-            } )
++        let source_map =
++          { (Source_map.Standard.empty ~inline_source_content) with
++             file
++          ; sourceroot = sourcemap_root
++          }
++        in
++        let spec =
++          { Source_map.Spec.output_file = sm_output_file
++          ; source_map
++          ; keep_empty = sourcemap_empty
++          }
++        in
++        Some spec)
+       else None
+     in
+     let params : (string * string) list = List.flatten set_param in
+@@ -391,6 +405,7 @@
+       $ sourcemap
+       $ sourcemap_inline_in_js
+       $ sourcemap_don't_inline_content
++      $ sourcemap_empty
+       $ sourcemap_root
+       $ target_env
+       $ output_file
+@@ -437,6 +452,12 @@
+     let doc = "Do not inline sources in source map." in
+     Arg.(value & flag & info [ "source-map-no-source" ] ~doc)
+   in
++  let sourcemap_empty =
++    let doc =
++      "Always generate empty source maps."
++    in
++    Arg.(value & flag & info [ "empty-sourcemap"; "empty-source-map" ] ~doc)
++  in
+   let sourcemap_root =
+     let doc = "root dir for source map." in
+     Arg.(value & opt (some string) None & info [ "source-map-root" ] ~doc)
+@@ -548,6 +569,7 @@
+       sourcemap
+       sourcemap_inline_in_js
+       sourcemap_don't_inline_content
++      sourcemap_empty
+       sourcemap_root
+       target_env
+       output_file
+@@ -570,12 +592,19 @@
+           | `Name file, _ -> Some file, Some (chop_extension file ^ ".map")
+           | `Stdout, _ -> None, None
+         in
+-        Some
+-          ( sm_output_file
+-          , { (Source_map.Standard.empty ~inline_source_content) with
+-              file
+-            ; sourceroot = sourcemap_root
+-            } )
++        let source_map =
++          { (Source_map.Standard.empty ~inline_source_content) with
++            file
++          ; sourceroot = sourcemap_root
++          }
++        in
++        let spec =
++          { Source_map.Spec.output_file = sm_output_file
++          ; source_map
++          ; keep_empty = sourcemap_empty
++          }
++        in
++        Some spec
+       else None
+     in
+     let params : (string * string) list = List.flatten set_param in
+@@ -626,6 +655,7 @@
+       $ sourcemap
+       $ sourcemap_inline_in_js
+       $ sourcemap_don't_inline_content
++      $ sourcemap_empty
+       $ sourcemap_root
+       $ target_env
+       $ output_file
+--- a/compiler/bin-js_of_ocaml/cmd_arg.mli
++++ b/compiler/bin-js_of_ocaml/cmd_arg.mli
+@@ -23,7 +23,7 @@
+   { common : Jsoo_cmdline.Arg.t
+   ; (* compile option *)
+     profile : Driver.profile option
+-  ; source_map : (string option * Source_map.Standard.t) option
++  ; source_map : Source_map.Spec.t option
+   ; runtime_files : string list
+   ; no_runtime : bool
+   ; include_runtime : bool
+--- a/compiler/bin-js_of_ocaml/compile.ml
++++ b/compiler/bin-js_of_ocaml/compile.ml
+@@ -155,12 +155,12 @@
+     ; include_runtime
+     ; effects
+     } =
+-  let source_map_base = Option.map ~f:snd source_map in
++  let source_map_base = Option.map ~f:(fun { Source_map.Spec.source_map; _ } -> source_map) source_map in
+   let source_map =
+     match source_map with
+-    | None -> No_sourcemap
+-    | Some (None, _) -> Inline
+-    | Some (Some file, _) -> File file
++    | None | Some { keep_empty = true; _ } -> No_sourcemap
++    | Some { output_file = None; keep_empty = false; _ } -> Inline
++    | Some { output_file = Some file; keep_empty = false; _ } -> File file
+   in
+   let include_cmis = toplevel && not no_cmis in
+   let custom_header = common.Jsoo_cmdline.Arg.custom_header in
+--- a/compiler/bin-js_of_ocaml/link.ml
++++ b/compiler/bin-js_of_ocaml/link.ml
+@@ -23,7 +23,7 @@
+
+ type t =
+   { common : Jsoo_cmdline.Arg.t
+-  ; source_map : (string option * Source_map.Standard.t) option
++  ; source_map : Source_map.Spec.t option
+   ; js_files : string list
+   ; output_file : string option
+   ; resolve_sourcemap_url : bool
+@@ -51,6 +51,12 @@
+     let doc = "Inline sourcemap in the generated JavaScript." in
+     Arg.(value & flag & info [ "source-map-inline" ] ~doc)
+   in
++  let sourcemap_empty =
++    let doc =
++      "Always generate empty source maps."
++    in
++    Arg.(value & flag & info [ "empty-sourcemap"; "empty-source-map" ] ~doc)
++  in
+   let sourcemap_root =
+     let doc = "root dir for source map." in
+     Arg.(value & opt (some string) None & info [ "source-map-root" ] ~doc)
+@@ -83,6 +89,7 @@
+       no_sourcemap
+       sourcemap
+       sourcemap_inline_in_js
++      sourcemap_empty
+       sourcemap_root
+       output_file
+       resolve_sourcemap_url
+@@ -100,12 +107,19 @@
+           | Some file -> Some file, Some (chop_extension file ^ ".map")
+           | None -> None, None
+         in
+-        Some
+-          ( sm_output_file
+-          , { (Source_map.Standard.empty ~inline_source_content:true) with
+-              file
+-            ; sourceroot = sourcemap_root
+-            } )
++        let source_map =
++          { (Source_map.Standard.empty ~inline_source_content:true) with
++            file
++          ; sourceroot = sourcemap_root
++          }
++        in
++        let spec =
++          { Source_map.Spec.output_file = sm_output_file
++          ; source_map
++          ; keep_empty = sourcemap_empty
++          }
++        in
++        Some spec
+       else None
+     in
+     `Ok
+@@ -126,6 +140,7 @@
+       $ no_sourcemap
+       $ sourcemap
+       $ sourcemap_inline_in_js
++      $ sourcemap_empty
+       $ sourcemap_root
+       $ output_file
+       $ resolve_sourcemap_url
+--- a/compiler/lib/link_js.ml
++++ b/compiler/lib/link_js.ml
+@@ -250,7 +250,7 @@
+     build_info, units, ic
+ end
+
+-let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~source_map =
++let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~(source_map : Source_map.Spec.t option) =
+   (* we currently don't do anything with [toplevel]. It could be used
+      to conditionally include link_info ?*)
+   ignore (toplevel : bool);
+@@ -340,10 +340,15 @@
+         match Line_reader.peek ic with
+         | None -> ()
+         | Some line ->
++            let drop_source_map =
++              match source_map with
++              | None | Some { keep_empty = true; _ } -> true
++              | Some { keep_empty = false; _ } -> false
++            in
+             (match
+                action
+                  ~resolve_sourcemap_url
+-                 ~drop_source_map:Poly.(source_map = None)
++                 ~drop_source_map
+                  file
+                  line
+              with
+@@ -468,8 +473,10 @@
+   let t = Timer.make () in
+   match source_map with
+   | None -> ()
+-  | Some (file, init_sm) ->
++  | Some { output_file = file; source_map = init_sm; keep_empty } ->
+       let sections =
++        if keep_empty then []
++        else
+         List.rev_map !sm ~f:(fun (sm, reloc, _offset) ->
+             let sm =
+               match (sm : Source_map.t) with
+@@ -536,7 +543,7 @@
+           Line_writer.write oc s);
+       if times () then Format.eprintf "  sourcemap: %a@." Timer.print t
+
+-let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~source_map =
++let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~(source_map : Source_map.Spec.t option) =
+   try link ~output ~linkall ~toplevel ~mklib ~files ~resolve_sourcemap_url ~source_map
+   with Build_info.Incompatible_build_info { key; first = f1, v1; second = f2, v2 } ->
+     let string_of_v = function
+--- a/compiler/lib/link_js.mli
++++ b/compiler/lib/link_js.mli
+@@ -24,5 +24,5 @@
+   -> toplevel:bool
+   -> files:string list
+   -> resolve_sourcemap_url:bool
+-  -> source_map:(string option * Source_map.Standard.t) option
++  -> source_map:Source_map.Spec.t option
+   -> unit
+--- a/compiler/lib/source_map.ml
++++ b/compiler/lib/source_map.ml
+@@ -760,3 +760,11 @@
+   ; sources : string list
+   ; names : string list
+   }
++
++module Spec = struct
++  type t =
++    { output_file : string option
++    ; source_map : Standard.t
++    ; keep_empty : bool
++    }
++end
+--- a/compiler/lib/source_map.mli
++++ b/compiler/lib/source_map.mli
+@@ -154,3 +154,11 @@
+   ; sources : string list
+   ; names : string list
+   }
++
++module Spec : sig
++  type t =
++    { output_file : string option
++    ; source_map : Standard.t
++    ; keep_empty : bool
++    }
++end

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-explicitly-ignore-unused-c-var.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-explicitly-ignore-unused-c-var.patch
@@ -1,0 +1,12 @@
+diff --git a/compiler/tests-jsoo/flush_stubs.c b/compiler/tests-jsoo/flush_stubs.c
+https://github.com/ocsigen/js_of_ocaml/pull/1560
+--- a/compiler/tests-jsoo/flush_stubs.c
++++ b/compiler/tests-jsoo/flush_stubs.c
+@@ -4,6 +4,7 @@
+ #include "caml/memory.h"
+
+ CAMLprim value flush_stdout_stderr (value unit) {
++  (void)unit;
+   CAMLparam0 ();   /* v is ignored */
+   fflush(stderr);
+   fflush(stdout);

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-fix-build_fs.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-fix-build_fs.patch
@@ -1,0 +1,45 @@
+--- a/compiler/bin-js_of_ocaml/build_fs.ml
++++ b/compiler/bin-js_of_ocaml/build_fs.ml
+@@ -51,9 +51,11 @@
+     {|
+ //Provides: jsoo_create_file_extern
+ function jsoo_create_file_extern(name,content){
+-  if(globalThis.jsoo_create_file)
++  if (globalThis.jsoo_create_file) {
+     globalThis.jsoo_create_file(name,content);
+-  else {
++  } else if (globalThis.caml_create_file) {
++    globalThis.caml_create_file(name,content);
++  } else {
+     if(!globalThis.jsoo_fs_tmp) globalThis.jsoo_fs_tmp = [];
+     globalThis.jsoo_fs_tmp.push({name:name,content:content});
+   }
+--- a/compiler/tests-full/fs.expected.js
++++ b/compiler/tests-full/fs.expected.js
+@@ -18,6 +18,8 @@
+    function a(a, b){
+     if(c.jsoo_create_file)
+      c.jsoo_create_file(a, b);
++    else if(c.caml_create_file)
++     c.caml_create_file(a, b);
+     else{
+      if(! c.caml_fs_tmp) c.caml_fs_tmp = [];
+      c.caml_fs_tmp.push({name: a, content: b});
+--- a/runtime/js/fs.js
++++ b/runtime/js/fs.js
+@@ -318,7 +318,7 @@
+ //Provides: caml_fs_init
+ //Requires: jsoo_create_file
+ function caml_fs_init() {
+-  var tmp = globalThis.jsoo_fs_tmp;
++  var tmp = [].concat(globalThis.jsoo_fs_tmp || [], globalThis.caml_fs_tmp || []);
+   if (tmp) {
+     for (var i = 0; i < tmp.length; i++) {
+       jsoo_create_file(tmp[i].name, tmp[i].content);
+@@ -326,5 +326,6 @@
+   }
+   globalThis.jsoo_create_file = jsoo_create_file;
+   globalThis.jsoo_fs_tmp = [];
++  globalThis.caml_fs_tmp = [];
+   return 0;
+ }

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-float32.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-float32.patch
@@ -1,0 +1,1531 @@
+--- a/compiler/lib-runtime-files/js_of_ocaml_compiler_runtime_files.ml
++++ b/compiler/lib-runtime-files/js_of_ocaml_compiler_runtime_files.ml
+@@ -33,6 +33,7 @@
+     ; graphics
+     ; hash
+     ; ieee_754
++    ; float32
+     ; int64
+     ; internalMod
+     ; ints
+--- a/compiler/lib-runtime-files/tests/all.ml
++++ b/compiler/lib-runtime-files/tests/all.ml
+@@ -21,6 +21,7 @@
+     +dynlink.js
+     +effect.js
+     +fail.js
++    +float32.js
+     +format.js
+     +fs.js
+     +fs_fake.js
+@@ -52,7 +53,8 @@
+     +toplevel.js
+     +unix.js
+     +weak.js
+-    +zstd.js |}];
++    +zstd.js
++    |}];
+   printl runtime;
+   [%expect
+     {|
+@@ -65,6 +67,7 @@
+     +domain.js
+     +effect.js
+     +fail.js
++    +float32.js
+     +format.js
+     +fs.js
+     +fs_fake.js
+@@ -94,7 +97,8 @@
+     +sys.js
+     +unix.js
+     +weak.js
+-    +zstd.js |}];
++    +zstd.js
++    |}];
+   printl extra;
+   [%expect {|
+     +dynlink.js
+--- a/compiler/lib/code.ml
++++ b/compiler/lib/code.ml
+@@ -326,6 +326,7 @@
+   | String of string
+   | NativeString of Native_string.t
+   | Float of float
++  | Float32 of float
+   | Float_array of float array
+   | Int of Targetint.t
+   | Int32 of Int32.t
+@@ -358,8 +359,10 @@
+     | NativeInt a, NativeInt b -> Some (Int32.equal a b)
+     | Float_array a, Float_array b -> Some (Array.equal Float.ieee_equal a b)
+     | Float a, Float b -> Some (Float.ieee_equal a b)
++    | Float32 a, Float32 b -> Some (Float.ieee_equal a b)
+     | String _, NativeString _ | NativeString _, String _ -> None
+     | Int _, Float _ | Float _, Int _ -> None
++    | Int _, Float32 _ | Float32 _, Int _ -> None
+     | Tuple ((0 | 254), _, _), Float_array _ -> None
+     | Float_array _, Tuple ((0 | 254), _, _) -> None
+     | ( Tuple _
+@@ -369,7 +372,7 @@
+         | Int _
+         | Int32 _
+         | NativeInt _
+-        | Float _
++        | Float _ | Float32 _
+         | Float_array _ ) ) -> Some false
+     | ( Float_array _
+       , ( String _
+@@ -378,13 +381,13 @@
+         | Int _
+         | Int32 _
+         | NativeInt _
+-        | Float _
++        | Float _ | Float32 _
+         | Tuple _ ) ) -> Some false
+     | ( String _
+-      , (Int64 _ | Int _ | Int32 _ | NativeInt _ | Float _ | Tuple _ | Float_array _) ) ->
++      , (Int64 _ | Int _ | Int32 _ | NativeInt _ | Float _ | Float32 _ | Tuple _ | Float_array _) ) ->
+         Some false
+     | ( NativeString _
+-      , (Int64 _ | Int _ | Int32 _ | NativeInt _ | Float _ | Tuple _ | Float_array _) ) ->
++      , (Int64 _ | Int _ | Int32 _ | NativeInt _ | Float _ | Float32 _ | Tuple _ | Float_array _) ) ->
+         Some false
+     | ( Int64 _
+       , ( String _
+@@ -392,10 +395,12 @@
+         | Int _
+         | Int32 _
+         | NativeInt _
+-        | Float _
++        | Float _ | Float32 _
+         | Tuple _
+         | Float_array _ ) ) -> Some false
+-    | Float _, (String _ | NativeString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ->
++    | Float _, (Float32 _ | String _ | NativeString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ->
++        Some false
++    | Float32 _, (Float _ | String _ | NativeString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ->
+         Some false
+     | ( (Int _ | Int32 _ | NativeInt _)
+       , (String _ | NativeString _ | Float_array _ | Int64 _ | Tuple (_, _, _)) ) ->
+@@ -404,8 +409,8 @@
+     | Int _, (Int32 _ | NativeInt _)
+     | Int32 _, (Int _ | NativeInt _)
+     | NativeInt _, (Int _ | Int32 _)
+-    | (Int32 _ | NativeInt _), Float _
+-    | Float _, (Int32 _ | NativeInt _) -> None
++    | (Int32 _ | NativeInt _), (Float _ | Float32 _)
++    | (Float _ | Float32 _), (Int32 _ | NativeInt _) -> None
+ end
+
+ type loc =
+@@ -491,6 +496,7 @@
+     | NativeString (Byte s) -> Format.fprintf f "%Sj" s
+     | NativeString (Utf (Utf8 s)) -> Format.fprintf f "%Sj" s
+     | Float fl -> Format.fprintf f "%.12g" fl
++    | Float32 fl -> Format.fprintf f "%.9g" fl
+     | Float_array a ->
+         Format.fprintf f "[|";
+         for i = 0 to Array.length a - 1 do
+@@ -878,7 +884,7 @@
+             match target with
+             | `Wasm -> true
+             | _ -> false)
+-      | String _ | NativeString _ | Float _ | Float_array _ | Int _ | Int64 _
++      | String _ | NativeString _ | Float _ | Float32 _ | Float_array _ | Int _ | Int64 _
+       | Tuple (_, _, _) -> ()
+     in
+     let check_prim_arg = function
+--- a/compiler/lib/code.mli
++++ b/compiler/lib/code.mli
+@@ -172,6 +172,7 @@
+   | String of string
+   | NativeString of Native_string.t
+   | Float of float
++  | Float32 of float
+   | Float_array of float array
+   | Int of Targetint.t
+   | Int32 of Int32.t  (** Only produced when compiling to WebAssembly. *)
+--- a/compiler/lib/eval.ml
++++ b/compiler/lib/eval.ml
+@@ -251,9 +251,11 @@
+   match a, b with
+   | Int i, Int j -> Some (Targetint.equal i j)
+   | Float a, Float b -> Some (Float.ieee_equal a b)
++  | Float32 a, Float32 b -> Some (Float.ieee_equal a b)
++  | Float32 _, Float _ | Float _, Float32 _ -> None
+   | NativeString a, NativeString b -> Some (Native_string.equal a b)
+   | String a, String b when Config.Flag.use_js_string () -> Some (String.equal a b)
+-  | Int _, Float _ | Float _, Int _ -> None
++  | Int _, (Float _ | Float32 _) | (Float _ | Float32 _), Int _ -> None
+   (* All other values may be distinct objects and thus different by [caml_js_equals]. *)
+   | String _, _
+   | _, String _
+@@ -413,6 +415,7 @@
+              ( Int32 _
+              | NativeInt _
+              | Float _
++             | Float32 _
+              | Tuple _
+              | String _
+              | NativeString _
+--- a/compiler/lib/flow.ml
++++ b/compiler/lib/flow.ml
+@@ -354,7 +354,9 @@
+   match a, b, target with
+   | Int i, Int j, _ -> Targetint.equal i j
+   | Float a, Float b, `JavaScript -> Float.bitwise_equal a b
++  | Float32 a, Float32 b, `JavaScript -> Float.bitwise_equal a b
+   | Float _, Float _, `Wasm -> false
++  | Float32 _, Float32 _, `Wasm -> false
+   | NativeString a, NativeString b, `JavaScript -> Native_string.equal a b
+   | NativeString _, NativeString _, `Wasm ->
+       false
+@@ -373,7 +375,7 @@
+   | Int64 _, Int64 _, _ -> false
+   | Tuple _, Tuple _, _ -> false
+   | Float_array _, Float_array _, _ -> false
+-  | (Int _ | Float _ | Int64 _ | Int32 _ | NativeInt _), _, _ -> false
++  | (Int _ | Float _ | Float32 _ | Int64 _ | Int32 _ | NativeInt _), _, _ -> false
+   | (String _ | NativeString _), _, _ -> false
+   | (Float_array _ | Tuple _), _, _ -> false
+
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -438,6 +438,7 @@
+       | Byte x -> Share.get_byte_string str_js_byte x ctx.Ctx.share, instrs
+       | Utf (Utf8 x) -> Share.get_utf_string str_js_utf8 x ctx.Ctx.share, instrs)
+   | Float f -> float_const f, instrs
++  | Float32 f -> float_const f, instrs
+   | Float_array a ->
+       ( Mlvalue.Array.make
+           ~tag:Obj.double_array_tag
+@@ -964,6 +965,13 @@
+   register_bin_prim "caml_le_float" `Pure (fun cx cy _ -> bool (J.EBin (J.Le, cx, cy)));
+   register_bin_prim "caml_gt_float" `Pure (fun cx cy _ -> bool (J.EBin (J.Lt, cy, cx)));
+   register_bin_prim "caml_lt_float" `Pure (fun cx cy _ -> bool (J.EBin (J.Lt, cx, cy)));
++  register_bin_prim "caml_eq_float32" `Pure (fun cx cy _ -> bool (J.EBin (J.EqEq, cx, cy)));
++  register_bin_prim "caml_neq_float32" `Pure (fun cx cy _ ->
++      bool (J.EBin (J.NotEq, cx, cy)));
++  register_bin_prim "caml_ge_float32" `Pure (fun cx cy _ -> bool (J.EBin (J.Le, cy, cx)));
++  register_bin_prim "caml_le_float32" `Pure (fun cx cy _ -> bool (J.EBin (J.Le, cx, cy)));
++  register_bin_prim "caml_gt_float32" `Pure (fun cx cy _ -> bool (J.EBin (J.Lt, cy, cx)));
++  register_bin_prim "caml_lt_float32" `Pure (fun cx cy _ -> bool (J.EBin (J.Lt, cx, cy)));
+   register_bin_prim "caml_add_float" `Pure (fun cx cy _ -> J.EBin (J.Plus, cx, cy));
+   register_bin_prim "caml_sub_float" `Pure (fun cx cy _ -> J.EBin (J.Minus, cx, cy));
+   register_bin_prim "caml_mul_float" `Pure (fun cx cy _ -> J.EBin (J.Mul, cx, cy));
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -25,7 +25,8 @@
+   | Const_base (Const_char c) -> Int (Targetint.of_int_exn (Char.code c))
+   | ((Const_base (Const_string (s, _))) [@if ocaml_version < (4, 11, 0)])
+   | ((Const_base (Const_string (s, _, _))) [@if ocaml_version >= (4, 11, 0)]) -> String s
+-  | Const_base (Const_float32 s | Const_unboxed_float32 s | Const_float s | Const_unboxed_float s) -> Float (float_of_string s)
++  | Const_base (Const_float32 s | Const_unboxed_float32 s) -> Float32 Float32.(of_string s |> to_float)
++  | Const_base (Const_float s | Const_unboxed_float s) -> Float (float_of_string s)
+   | Const_base (Const_int32 i | Const_unboxed_int32 i) -> (
+       match Config.target () with
+       | `JavaScript -> Int (Targetint.of_int32_warning_on_overflow i)
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -477,6 +477,8 @@
+
+   let ident_native = ident_of_custom (Obj.repr 0n)
+
++  let ident_f32 = ident_of_custom (Obj.repr 0.s)
++
+   let rec parse x =
+     if Obj.is_block x
+     then
+@@ -490,6 +492,8 @@
+       else if tag = Obj.custom_tag
+       then
+         match ident_of_custom x with
++        | Some name when same_ident name ident_f32 ->
++          Float32 ((Obj.magic x : float32) |> Float32.to_float)
+         | Some name when same_ident name ident_32 -> (
+             let i : int32 = Obj.magic x in
+             match Config.target () with
+@@ -518,6 +522,7 @@
+   let inlined = function
+     | String _ | NativeString _ -> false
+     | Float _ -> true
++    | Float32 _ -> true
+     | Float_array _ -> false
+     | Int64 _ -> false
+     | Tuple _ -> false
+--- a/compiler/lib/stdlib.ml
++++ b/compiler/lib/stdlib.ml
+@@ -417,6 +417,17 @@
+   external ( >= ) : t -> t -> bool = "%greaterequal"
+ end
+
++module Float32 = struct
++  type t = float32
++
++  external of_float : float -> t = "%float32offloat"
++  external to_float : t -> float = "%floatoffloat32"
++
++  (* In javascript/wasm, we define float32 parsing as rounding the 64-bit result.
++     This is not equivalent to native code, which parses to 32 bits directly. *)
++  let of_string s = float_of_string s |> of_float
++end
++
+ module Bool = struct
+   external ( <> ) : bool -> bool -> bool = "%notequal"
+
+--- a/compiler/lib-wasm/gc_target.ml
++++ b/compiler/lib-wasm/gc_target.ml
+@@ -170,6 +170,22 @@
+                 ]
+           })
+
++  let float32_type =
++    register_type "float32" (fun () ->
++        let* custom_operations = custom_operations_type in
++        let* custom = custom_type in
++        return
++          { supertype = Some custom
++          ; final = true
++          ; typ =
++              W.Struct
++                [ { mut = false
++                  ; typ = Value (Ref { nullable = false; typ = Type custom_operations })
++                  }
++                ; { mut = false; typ = Value F32 }
++                ]
++          })
++
+   let int32_type =
+     register_type "int32" (fun () ->
+         let* custom_operations = custom_operations_type in
+@@ -853,6 +869,18 @@
+     in
+     if_mismatch
+
++  let make_float32 e =
++    let* custom_operations = Type.custom_operations_type in
++    let* float32_ops =
++      register_import
++        ~name:"float32_ops"
++        (Global
++           { mut = false; typ = Ref { nullable = false; typ = Type custom_operations } })
++    in
++    let* ty = Type.float32_type in
++    let* e = e in
++    return (W.StructNew (ty, [ GlobalGet float32_ops; e ]))
++
+   let make_int32 ~kind e =
+     let* custom_operations = Type.custom_operations_type in
+     let* int32_ops =
+@@ -1023,6 +1051,9 @@
+     | Float f ->
+         let* ty = Type.float_type in
+         return (Const, W.StructNew (ty, [ Const (F64 f) ]))
++    | Float32 f ->
++        let* e = Memory.make_float32 (return (W.Const (F32 f))) in
++        return (Const, e)
+     | Float_array l ->
+         let l = Array.to_list l in
+         let* ty = Type.float_array_type in
+--- /dev/null
++++ b/compiler/tests-jsoo/test_marshal_float32.ml
+@@ -0,0 +1,47 @@
++
++(* In javascript, float32s are represented as floats.
++   In native code and wasm, float32s are custom blocks containing a float32 field. *)
++
++external float_of_float32 : float32 -> float = "%floatoffloat32"
++
++type float64s = { a : float; b : float }
++
++let%expect_test "float64 javascript" [@tags "js-only", "no-wasm"] =
++  let f64 = Marshal.to_string { a = 123.; b = 456. } [] in
++  Printf.printf "%S" f64;
++  [%expect
++    {| "\132\149\166\190\000\000\000\n\000\000\000\001\000\000\000\003\000\000\000\003\b\000\000\b\254\000{\001\001\200" |}];
++  let f64 : float64s = Marshal.from_string f64 0 in
++  Printf.printf "%f %f" f64.a f64.b;
++  [%expect
++    {| 123.000000 456.000000 |}]
++
++let%expect_test "float64 wasm" [@tags "wasm-only"] =
++  let f64 = Marshal.to_string { a = 123.; b = 456. } [] in
++  Printf.printf "%S" f64;
++  [%expect
++    {| "\132\149\166\190\000\000\000\018\000\000\000\001\000\000\000\005\000\000\000\003\014\002\000\000\000\000\000\192^@\000\000\000\000\000\128|@" |}];
++  let f64 : float64s = Marshal.from_string f64 0 in
++  Printf.printf "%f %f" f64.a f64.b;
++  [%expect
++    {| 123.000000 456.000000 |}]
++
++type float32s = { a : float32; b : float32 }
++
++let%expect_test "float32 javascript" [@tags "js-only", "no-wasm"] =
++  let f32 = Marshal.to_string { a = 123.s; b = 456.s } [] in
++  Printf.printf "%S" f32;
++  [%expect
++    {| "\132\149\166\190\000\000\000\006\000\000\000\001\000\000\000\003\000\000\000\003\160\000{\001\001\200" |}];
++  let f32 : float32s = Marshal.from_string f32 0 in
++  Printf.printf "%f %f" (float_of_float32 f32.a) (float_of_float32 f32.b);
++  [%expect {| 123.000000 456.000000 |}]
++
++let%expect_test "float32 wasm" [@tags "wasm-only"] =
++  let f32 = Marshal.to_string { a = 123.s; b = 456.s } [] in
++  Printf.printf "%S" f32;
++  [%expect
++    {| "\132\149\166\190\000\000\000\021\000\000\000\003\000\000\000\t\000\000\000\t\160\025_f32\000B\246\000\000\025_f32\000C\228\000\000" |}];
++  let f32 : float32s = Marshal.from_string f32 0 in
++  Printf.printf "%f %f" (float_of_float32 f32.a) (float_of_float32 f32.b);
++  [%expect {| 123.000000 456.000000 |}]
+--- /dev/null
++++ b/runtime/js/float32.js
+@@ -0,0 +1,419 @@
++
++/*
++    32-bit floats are represented as javascript numbers, i.e. 64-bit floats.
++    Each operation is performed in 64-bit precision and then rounded to the
++    nearest 32-bit float. This is not identical to using true 32-bit operations.
++    For example, if rounding an exact result to 64 bits places it halfway
++    between the two nearest 32-bit numbers, rounding it again to 32 bits
++    may not result in the closest 32-bit number to the exact result.
++
++    Marshalled float32s therefore look like normal floats. This means that
++    javascript programs are not be able to read float32 data marshalled
++    by native programs and vice versa.
++*/
++
++//Provides: caml_float_of_float32 const
++function caml_float_of_float32(x) {
++    return x;
++}
++
++//Provides: caml_float32_of_float const
++function caml_float32_of_float(x) {
++    return Math.fround(x);
++}
++
++//Provides: caml_float32_of_int const
++function caml_float32_of_int(x) {
++    return Math.fround(x);
++}
++
++//Provides: caml_int_of_float32 const
++function caml_int_of_float32(x) {
++    return x | 0;
++}
++
++//Provides: caml_float32_of_bits_bytecode const
++//Requires: caml_int32_float_of_bits
++let caml_float32_of_bits_bytecode = caml_int32_float_of_bits
++
++//Provides: caml_float32_to_bits_bytecode const
++//Requires: caml_int32_bits_of_float
++let caml_float32_to_bits_bytecode = caml_int32_bits_of_float
++
++//Provides: caml_float32_of_int64_bytecode const
++//Requires: caml_int64_to_float
++function caml_float32_of_int64_bytecode(x) {
++    return Math.fround(caml_int64_to_float(x));
++}
++
++//Provides: caml_float32_to_int64_bytecode const
++//Requires: caml_int64_of_float
++let caml_float32_to_int64_bytecode = caml_int64_of_float
++
++//Provides: caml_float32_of_string (const)
++//Requires: caml_float_of_string
++function caml_float32_of_string(x) {
++    return Math.fround(caml_float_of_string(x));
++}
++
++//Provides: caml_format_float32 const
++//Requires: caml_format_float
++let caml_format_float32 = caml_format_float
++
++//Provides: caml_float32_compare const
++//Requires: caml_float_compare
++let caml_float32_compare = caml_float_compare
++
++//Provides: caml_add_float32 const
++function caml_add_float32(x, y) {
++    return Math.fround(x + y);
++}
++
++//Provides: caml_sub_float32 const
++function caml_sub_float32(x, y) {
++    return Math.fround(x - y);
++}
++
++//Provides: caml_mul_float32 const
++function caml_mul_float32(x, y) {
++    return Math.fround(x * y);
++}
++
++//Provides: caml_div_float32 const
++function caml_div_float32(x, y) {
++    return Math.fround(x / y);
++}
++
++//Provides: caml_fmod_float32_bytecode const
++function caml_fmod_float32_bytecode(x, y) {
++    return Math.fround(x % y);
++}
++
++//Provides: caml_neg_float32 const
++function caml_neg_float32(x) {
++    return -x; // Result is exact
++}
++
++//Provides: caml_abs_float32 const
++function caml_abs_float32(x) {
++    return Math.abs(x); // Result is exact
++}
++
++//Provides: caml_modf_float32 const
++//Requires: caml_modf_float
++let caml_modf_float32 = caml_modf_float // Result is exact
++
++//Provides: caml_acos_float32_bytecode const
++function caml_acos_float32_bytecode(x) {
++    return Math.fround(Math.acos(x));
++}
++
++//Provides: caml_asin_float32_bytecode const
++function caml_asin_float32_bytecode(x) {
++    return Math.fround(Math.asin(x));
++}
++
++//Provides: caml_atan_float32_bytecode const
++function caml_atan_float32_bytecode(x) {
++    return Math.fround(Math.atan(x));
++}
++
++//Provides: caml_atan2_float32_bytecode const
++function caml_atan2_float32_bytecode(x, y) {
++    return Math.fround(Math.atan2(x, y));
++}
++
++//Provides: caml_ceil_float32_bytecode const
++function caml_ceil_float32_bytecode(x) {
++    return Math.fround(Math.ceil(x));
++}
++
++//Provides: caml_cos_float32_bytecode const
++function caml_cos_float32_bytecode(x) {
++    return Math.fround(Math.cos(x));
++}
++
++//Provides: caml_exp_float32_bytecode const
++function caml_exp_float32_bytecode(x) {
++    return Math.fround(Math.exp(x));
++}
++
++//Provides: caml_floor_float32_bytecode const
++function caml_floor_float32_bytecode(x) {
++    return Math.fround(Math.floor(x));
++}
++
++//Provides: caml_log_float32_bytecode const
++function caml_log_float32_bytecode(x) {
++    return Math.fround(Math.log(x));
++}
++
++//Provides: caml_power_float32_bytecode const
++function caml_power_float32_bytecode(x, y) {
++    return Math.fround(Math.pow(x, y));
++}
++
++//Provides: caml_sin_float32_bytecode const
++function caml_sin_float32_bytecode(x) {
++    return Math.fround(Math.sin(x));
++}
++
++//Provides: caml_sqrt_float32_bytecode const
++function caml_sqrt_float32_bytecode(x) {
++    return Math.fround(Math.sqrt(x));
++}
++
++//Provides: caml_tan_float32_bytecode const
++function caml_tan_float32_bytecode(x) {
++    return Math.fround(Math.tan(x));
++}
++
++//Provides: caml_nextafter_float32_bytecode const
++//Requires: caml_int32_bits_of_float, caml_int32_float_of_bits
++function caml_nextafter_float32_bytecode(x, y) {
++    if (isNaN(x) || isNaN(y)) return NaN;
++    if (x == y) return y;
++    if (x == 0) {
++        if (y < 0)
++            return -Math.pow(2, -149)
++        else
++            return Math.pow(2, -149)
++    }
++    var bits = caml_int32_bits_of_float(x);
++    if ((x < y) == (x > 0))
++        bits = bits + 1
++    else
++        bits = bits - 1
++    return caml_int32_float_of_bits(bits);
++}
++
++//Provides: caml_trunc_float32_bytecode const
++function caml_trunc_float32_bytecode(x) {
++    return Math.fround(Math.trunc(x));
++}
++
++//Provides: caml_classify_float32_bytecode const
++function caml_classify_float32_bytecode(x) {
++    if (isFinite(x)) {
++        if (Math.abs(x) >= 1.1754943508222875e-38) return 0;
++        if (x != 0) return 1;
++        return 2;
++    }
++    return isNaN(x) ? 4 : 3;
++}
++
++//Provides: caml_ldexp_float32_bytecode const
++//Requires: caml_ldexp_float
++function caml_ldexp_float32_bytecode(x, y) {
++    return Math.fround(caml_ldexp_float(x, y));
++}
++
++//Provides: caml_frexp_float32 const
++//Requires: caml_frexp_float
++let caml_frexp_float32 = caml_frexp_float // Result is exact
++
++//Provides: caml_copysign_float32_bytecode const
++//Requires: caml_copysign_float
++let caml_copysign_float32_bytecode = caml_copysign_float // Result is exact
++
++//Provides: caml_signbit_float32_bytecode const
++//Requires: caml_signbit_float
++let caml_signbit_float32_bytecode = caml_signbit_float
++
++//Provides: caml_expm1_float32_bytecode const
++function caml_expm1_float32_bytecode(x) {
++    return Math.fround(Math.expm1(x));
++}
++
++//Provides: caml_exp2_float32_bytecode const
++function caml_exp2_float32_bytecode(x) {
++    return Math.fround(Math.pow(2, x));
++}
++
++//Provides: caml_log1p_float32_bytecode const
++function caml_log1p_float32_bytecode(x) {
++    return Math.fround(Math.log1p(x));
++}
++
++//Provides: caml_log2_float32_bytecode const
++function caml_log2_float32_bytecode(x) {
++    return Math.fround(Math.log2(x));
++}
++
++//Provides: caml_hypot_float32_bytecode const
++function caml_hypot_float32_bytecode(x, y) {
++    return Math.fround(Math.hypot(x, y));
++}
++
++//Provides: caml_log10_float32_bytecode const
++function caml_log10_float32_bytecode(x) {
++    return Math.fround(Math.log10(x));
++}
++
++//Provides: caml_cosh_float32_bytecode const
++function caml_cosh_float32_bytecode(x) {
++    return Math.fround(Math.cosh(x));
++}
++
++//Provides: caml_acosh_float32_bytecode const
++function caml_acosh_float32_bytecode(x) {
++    return Math.fround(Math.acosh(x));
++}
++
++//Provides: caml_sinh_float32_bytecode const
++function caml_sinh_float32_bytecode(x) {
++    return Math.fround(Math.sinh(x));
++}
++
++//Provides: caml_asinh_float32_bytecode const
++function caml_asinh_float32_bytecode(x) {
++    return Math.fround(Math.asinh(x));
++}
++
++//Provides: caml_tanh_float32_bytecode const
++function caml_tanh_float32_bytecode(x) {
++    return Math.fround(Math.tanh(x));
++}
++
++//Provides: caml_atanh_float32_bytecode const
++function caml_atanh_float32_bytecode(x) {
++    return Math.fround(Math.atanh(x));
++}
++
++//Provides: caml_round_float32_bytecode const
++//Requires: caml_round_float
++function caml_round_float32_bytecode(x) {
++    return Math.fround(caml_round_float(x));
++}
++
++//Provides: caml_cbrt_float32_bytecode const
++function caml_cbrt_float32_bytecode(x) {
++    return Math.fround(Math.cbrt(x));
++}
++
++//Provides: caml_erf_float32_bytecode const
++//Requires: caml_erf_float
++function caml_erf_float32_bytecode(x) {
++    return Math.fround(caml_erf_float(x));
++}
++
++//Provides: caml_erfc_float32_bytecode const
++//Requires: caml_erfc_float
++function caml_erfc_float32_bytecode(x) {
++    return Math.fround(caml_erfc_float(x));
++}
++
++//Provides: caml_fma_float32_bytecode const
++//Requires: caml_fma_float
++function caml_fma_float32_bytecode(x, y, z) {
++    return Math.fround(caml_fma_float(x, y, z));
++}
++
++//Provides: caml_simd_float32_min_bytecode const
++function caml_simd_float32_min_bytecode(x, y) {
++    return x < y ? x : y;
++}
++
++//Provides: caml_simd_float32_max_bytecode const
++function caml_simd_float32_max_bytecode(x, y) {
++    return x > y ? x : y;
++}
++
++//Provides: caml_simd_cast_float32_int64_bytecode const
++//Requires: caml_int64_of_float, caml_round_float32_bytecode
++function caml_simd_cast_float32_int64_bytecode(x) {
++    return caml_int64_of_float(caml_round_float32_bytecode(x));
++}
++
++//Provides: caml_simd_float32_round_current_bytecode const
++//Requires: caml_round_float32_bytecode
++function caml_simd_float32_round_current_bytecode(x) {
++    return caml_round_float32_bytecode(x);
++}
++
++//Provides: caml_simd_float32_round_neg_inf_bytecode const
++function caml_simd_float32_round_neg_inf_bytecode(x) {
++    return Math.fround(Math.floor(x));
++}
++
++//Provides: caml_simd_float32_round_pos_inf_bytecode const
++function caml_simd_float32_round_pos_inf_bytecode(x) {
++    return Math.fround(Math.ceil(x));
++}
++
++//Provides: caml_simd_float32_round_towards_zero_bytecode const
++function caml_simd_float32_round_towards_zero_bytecode(x) {
++    return Math.fround(Math.trunc(x));
++}
++
++//Provides: caml_make_unboxed_float32_vect_bytecode const (const)
++//Requires: caml_make_float_vect
++let caml_make_unboxed_float32_vect_bytecode = caml_make_float_vect
++
++//Provides: caml_ba_float32_get_1
++//Requires: caml_ba_get_1
++let caml_ba_float32_get_1 = caml_ba_get_1
++
++//Provides: caml_ba_float32_get_2
++//Requires: caml_ba_get_2
++let caml_ba_float32_get_2 = caml_ba_get_2
++
++//Provides: caml_ba_float32_get_3
++//Requires: caml_ba_get_3
++let caml_ba_float32_get_3 = caml_ba_get_3
++
++//Provides: caml_ba_float32_set_1
++//Requires: caml_ba_set_1
++let caml_ba_float32_set_1 = caml_ba_set_1
++
++//Provides: caml_ba_float32_set_2
++//Requires: caml_ba_set_2
++let caml_ba_float32_set_2 = caml_ba_set_2
++
++//Provides: caml_ba_float32_set_3
++//Requires: caml_ba_set_3
++let caml_ba_float32_set_3 = caml_ba_set_3
++
++//Provides: caml_ba_uint8_getf32
++//Requires: caml_ba_uint8_get32, caml_int32_float_of_bits
++function caml_ba_uint8_getf32(ba, i0) {
++    return caml_int32_float_of_bits(caml_ba_uint8_get32(ba, i0));
++}
++
++//Provides: caml_ba_uint8_setf32
++//Requires: caml_ba_uint8_set32, caml_int32_bits_of_float
++function caml_ba_uint8_setf32(ba, i0, v) {
++    return caml_ba_uint8_set32(ba, i0, caml_int32_bits_of_float(v));
++}
++
++//Provides: caml_string_getf32
++//Requires: caml_string_get32, caml_int32_float_of_bits
++function caml_string_getf32(s, i) {
++    return caml_int32_float_of_bits(caml_string_get32(s, i));
++}
++
++//Provides: caml_bytes_getf32
++//Requires: caml_bytes_get32, caml_int32_float_of_bits
++function caml_bytes_getf32(s, i) {
++    return caml_int32_float_of_bits(caml_bytes_get32(s, i));
++}
++
++//Provides: caml_bytes_setf32
++//Requires: caml_bytes_set32, caml_int32_bits_of_float
++function caml_bytes_setf32(s, i, f32) {
++    return caml_bytes_set32(s, i, caml_int32_bits_of_float(f32));
++}
++
++//Provides: caml_string_setf32
++//Requires: caml_failwith
++//If: js-string
++function caml_string_setf32(s, i, f32) {
++    caml_failwith("caml_string_setf32");
++}
++
++//Provides: caml_string_setf32
++//Requires: caml_bytes_setf32
++//If: !js-string
++function caml_string_setf32(s, i, f32) {
++    return caml_bytes_setf32(s, i, f32);
++}
+--- a/runtime/wasm/custom.wat
++++ b/runtime/wasm/custom.wat
+@@ -16,6 +16,7 @@
+ ;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+ (module
++   (import "float32" "float32_ops" (global $float32_ops (ref $custom_operations)))
+    (import "int32" "int32_ops" (global $int32_ops (ref $custom_operations)))
+    (import "int32" "nativeint_ops"
+       (global $nativeint_ops (ref $custom_operations)))
+@@ -137,6 +138,7 @@
+       (call $caml_register_custom_operations (global.get $nativeint_ops))
+       (call $caml_register_custom_operations (global.get $int64_ops))
+       (call $caml_register_custom_operations (global.get $bigarray_ops))
++      (call $caml_register_custom_operations (global.get $float32_ops))
+       (global.set $initialized (i32.const 1)))
+
+   (func (export "caml_custom_identifier") (param $v (ref eq)) (result (ref eq))
+--- /dev/null
++++ b/runtime/wasm/float32.wat
+@@ -0,0 +1,708 @@
++(module
++    (import "fail" "caml_failwith"
++        (func $caml_failwith (param (ref eq))))
++    (import "marshal" "caml_serialize_int_4"
++        (func $caml_serialize_int_4 (param (ref eq)) (param i32)))
++    (import "marshal" "caml_deserialize_int_4"
++        (func $caml_deserialize_int_4 (param (ref eq)) (result i32)))
++    (import "int32" "Int32_val"
++        (func $Int32_val (param (ref eq)) (result i32)))
++    (import "int32" "caml_copy_int32"
++        (func $caml_copy_int32 (param i32) (result (ref eq))))
++    (import "int64" "Int64_val"
++        (func $Int64_val (param (ref eq)) (result i64)))
++    (import "int64" "caml_copy_int64"
++        (func $caml_copy_int64 (param i64) (result (ref eq))))
++    (import "float" "caml_float_of_string"
++        (func $caml_float_of_string (param (ref eq)) (result (ref eq))))
++    (import "float" "caml_format_float"
++        (func $caml_format_float (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "float" "caml_fma_float"
++        (func $caml_fma_float (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "float" "caml_erf_float"
++        (func $caml_erf_float (param f64) (result f64)))
++    (import "float" "caml_erfc_float"
++        (func $caml_erfc_float (param f64) (result f64)))
++    (import "float" "caml_frexp_float"
++        (func $caml_frexp_float (param (ref eq)) (result (ref eq))))
++    (import "float" "caml_ldexp_float"
++      (func $caml_ldexp_float (param f64) (param (ref eq)) (result f64)))
++    (import "bigarray" "caml_ba_get_1"
++        (func $caml_ba_get_1 (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "bigarray" "caml_ba_get_2"
++        (func $caml_ba_get_2 (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "bigarray" "caml_ba_get_3"
++        (func $caml_ba_get_3 (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "bigarray" "caml_ba_set_1"
++        (func $caml_ba_set_1 (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "bigarray" "caml_ba_set_2"
++        (func $caml_ba_set_2 (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "bigarray" "caml_ba_set_3"
++        (func $caml_ba_set_3 (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))))
++    (import "bigarray" "caml_ba_uint8_get32"
++        (func $caml_ba_uint8_get32 (param (ref eq)) (param (ref eq)) (result i32)))
++    (import "bigarray" "caml_ba_uint8_set32"
++        (func $caml_ba_uint8_set32 (param (ref eq)) (param (ref eq)) (param i32) (result (ref eq))))
++    (import "string" "caml_string_get32"
++        (func $caml_string_get32 (param (ref eq)) (param (ref eq)) (result i32)))
++    (import "string" "caml_bytes_get32"
++        (func $caml_bytes_get32 (param (ref eq)) (param (ref eq)) (result i32)))
++    (import "string" "caml_bytes_set32"
++        (func $caml_bytes_set32 (param (ref eq)) (param (ref eq)) (param i32) (result (ref eq))))
++    (import "array" "caml_make_vect"
++        (func $caml_make_vect (param (ref eq)) (param (ref eq)) (result (ref eq))))
++
++    (import "Math" "sin" (func $sin (param f64) (result f64)))
++    (import "Math" "cos" (func $cos (param f64) (result f64)))
++    (import "Math" "tan" (func $tan (param f64) (result f64)))
++    (import "Math" "asin" (func $asin (param f64) (result f64)))
++    (import "Math" "acos" (func $acos (param f64) (result f64)))
++    (import "Math" "atan" (func $atan (param f64) (result f64)))
++    (import "Math" "atan2" (func $atan2 (param f64) (param f64) (result f64)))
++    (import "Math" "exp" (func $exp (param f64) (result f64)))
++    (import "Math" "log" (func $log (param f64) (result f64)))
++    (import "Math" "pow" (func $pow (param f64) (param f64) (result f64)))
++    (import "Math" "fmod" (func $fmod (param f64) (param f64) (result f64)))
++    (import "Math" "expm1" (func $expm1 (param f64) (result f64)))
++    (import "Math" "log1p" (func $log1p (param f64) (result f64)))
++    (import "Math" "log2" (func $log2 (param f64) (result f64)))
++    (import "Math" "hypot" (func $hypot (param f64) (param f64) (result f64)))
++    (import "Math" "log10" (func $log10 (param f64) (result f64)))
++    (import "Math" "cosh" (func $cosh (param f64) (result f64)))
++    (import "Math" "acosh" (func $acosh (param f64) (result f64)))
++    (import "Math" "sinh" (func $sinh (param f64) (result f64)))
++    (import "Math" "asinh" (func $asinh (param f64) (result f64)))
++    (import "Math" "tanh" (func $tanh (param f64) (result f64)))
++    (import "Math" "atanh" (func $atanh (param f64) (result f64)))
++    (import "Math" "cbrt" (func $cbrt (param f64) (result f64)))
++
++    (type $float (struct (field f64)))
++
++    (func $box_float
++        (param $f f64) (result (ref eq))
++        (struct.new $float (local.get $f)))
++
++    (func $unbox_float
++        (param $f (ref eq)) (result f64)
++        (struct.get $float 0 (ref.cast (ref $float) (local.get $f))))
++
++    (type $block (array (mut (ref eq))))
++    (type $bytes (array (mut i8)))
++    (type $compare
++        (func (param (ref eq)) (param (ref eq)) (param i32) (result i32)))
++    (type $hash
++        (func (param (ref eq)) (result i32)))
++    (type $fixed_length (struct (field $bsize_32 i32) (field $bsize_64 i32)))
++    (type $serialize
++        (func (param (ref eq)) (param (ref eq)) (result i32) (result i32)))
++    (type $deserialize (func (param (ref eq)) (result (ref eq)) (result i32)))
++    (type $dup (func (param (ref eq)) (result (ref eq))))
++    (type $custom_operations
++        (struct
++            (field $id (ref $bytes))
++            (field $compare (ref null $compare))
++            (field $compare_ext (ref null $compare))
++            (field $hash (ref null $hash))
++            (field $fixed_length (ref null $fixed_length))
++            (field $serialize (ref null $serialize))
++            (field $deserialize (ref null $deserialize))
++            (field $dup (ref null $dup))))
++    (type $custom (sub (struct (field (ref $custom_operations)))))
++
++    (global $float32_ops (export "float32_ops") (ref $custom_operations)
++        (struct.new $custom_operations
++            (array.new_fixed $bytes 4 (i32.const 95) (i32.const 102) (i32.const 51) (i32.const 50)) ;; "_f32"
++            (ref.func $float32_cmp)
++            (ref.null $compare)
++            (ref.func $float32_hash)
++            (struct.new $fixed_length (i32.const 4) (i32.const 4))
++            (ref.func $float32_serialize)
++            (ref.func $float32_deserialize)
++            (ref.func $float32_dup)))
++
++    (type $float32
++        (sub final $custom (struct (field (ref $custom_operations)) (field f32))))
++
++    (func $box_float32
++        (param $f f32) (result (ref eq))
++        (struct.new $float32 (global.get $float32_ops) (local.get $f)))
++
++    (func $unbox_float32
++        (param $f (ref eq)) (result f32)
++        (struct.get $float32 1 (ref.cast (ref $float32) (local.get $f))))
++
++    (func $float32_cmp
++        (param $v1 (ref eq)) (param $v2 (ref eq)) (param i32) (result i32)
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get $v1)))
++        (local.set $y (call $unbox_float32 (local.get $v2)))
++        (i32.add
++            (i32.sub (f32.gt (local.get $x) (local.get $y))
++                     (f32.lt (local.get $x) (local.get $y)))
++            (i32.sub (f32.eq (local.get $x) (local.get $x))
++                     (f32.eq (local.get $y) (local.get $y)))))
++
++    (func $float32_hash
++        (param $v (ref eq)) (result i32)
++        (i32.reinterpret_f32 (call $unbox_float32 (local.get $v))))
++
++    (func $float32_serialize
++        (param $s (ref eq)) (param $v (ref eq)) (result i32) (result i32)
++        (call $caml_serialize_int_4 (local.get $s)
++            (i32.reinterpret_f32 (call $unbox_float32 (local.get $v))))
++        (tuple.make 2 (i32.const 4) (i32.const 4)))
++
++    (func $float32_deserialize
++        (param $s (ref eq)) (result (ref eq)) (result i32)
++        (tuple.make 2
++            (call $box_float32 (f32.reinterpret_i32 (call $caml_deserialize_int_4 (local.get $s))))
++            (i32.const 4)))
++
++    (func $float32_dup
++        (param $v (ref eq)) (result (ref eq))
++        (local $d (ref $float32))
++        (local.set $d (ref.cast (ref $float32) (local.get $v)))
++        (struct.new $float32
++            (struct.get $float32 0 (local.get $d))
++            (struct.get $float32 1 (local.get $d))))
++
++    (func $caml_float_of_float32 (export "caml_float_of_float32")
++        (param $f32 (ref eq)) (result (ref eq))
++        (call $box_float
++            (f64.promote_f32 (call $unbox_float32 (local.get $f32)))))
++
++    (func $caml_float32_of_float (export "caml_float32_of_float")
++        (param $f64 (ref eq)) (result (ref eq))
++        (call $box_float32
++            (f32.demote_f64 (call $unbox_float (local.get $f64)))))
++
++    (func (export "caml_float32_of_int")
++        (param $i (ref eq)) (result (ref eq))
++        (call $box_float32
++            (f32.convert_i32_s (i31.get_s (ref.cast (ref i31) (local.get $i))))))
++
++    (func (export "caml_int_of_float32")
++        (param $f (ref eq)) (result (ref eq))
++        (ref.i31
++            (i32.trunc_sat_f32_s (call $unbox_float32 (local.get $f)))))
++
++    (func (export "caml_float32_of_bits_bytecode")
++        (param $i (ref eq)) (result (ref eq))
++        (call $box_float32
++            (f32.reinterpret_i32 (call $Int32_val (local.get $i)))))
++
++    (func (export "caml_float32_to_bits_bytecode")
++        (param $f (ref eq)) (result (ref eq))
++        (call $caml_copy_int32
++            (i32.reinterpret_f32 (call $unbox_float32 (local.get $f)))))
++
++    (func (export "caml_float32_of_int64_bytecode")
++        (param $i (ref eq)) (result (ref eq))
++        (call $box_float32
++            (f32.convert_i64_s (call $Int64_val (local.get $i)))))
++
++    (func (export "caml_float32_to_int64_bytecode")
++        (param $f (ref eq)) (result (ref eq))
++        (call $caml_copy_int64
++            (i64.trunc_sat_f32_s (call $unbox_float32 (local.get $f)))))
++
++    (func (export "caml_float32_of_string")
++        (param $s (ref eq)) (result (ref eq))
++        (call $caml_float32_of_float (call $caml_float_of_string (local.get $s))))
++
++    (func (export "caml_format_float32")
++        (param $s (ref eq)) (param $f (ref eq)) (result (ref eq))
++        (call $caml_format_float (local.get $s) (call $caml_float_of_float32 (local.get $f))))
++
++    (func (export "caml_float32_compare")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (ref.i31
++            (i32.add
++            (i32.sub (f32.gt (local.get $x) (local.get $y))
++                     (f32.lt (local.get $x) (local.get $y)))
++            (i32.sub (f32.eq (local.get $x) (local.get $x))
++                     (f32.eq (local.get $y) (local.get $y))))))
++
++    (func (export "caml_eq_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (ref.i31 (f32.eq (local.get $x) (local.get $y))))
++
++    (func (export "caml_neq_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (ref.i31 (f32.ne (local.get $x) (local.get $y))))
++
++    (func (export "caml_ge_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (ref.i31 (f32.ge (local.get $x) (local.get $y))))
++
++   (func (export "caml_le_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (ref.i31 (f32.le (local.get $x) (local.get $y))))
++
++    (func (export "caml_gt_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (ref.i31 (f32.gt (local.get $x) (local.get $y))))
++
++    (func (export "caml_lt_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (ref.i31 (f32.lt (local.get $x) (local.get $y))))
++
++    (func (export "caml_add_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (call $box_float32 (f32.add (local.get $x) (local.get $y))))
++
++    (func (export "caml_sub_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (call $box_float32 (f32.sub (local.get $x) (local.get $y))))
++
++    (func (export "caml_mul_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (call $box_float32 (f32.mul (local.get $x) (local.get $y))))
++
++    (func (export "caml_div_float32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (call $box_float32 (f32.div (local.get $x) (local.get $y))))
++
++    (func (export "caml_neg_float32")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.neg (local.get $x))))
++
++    (func (export "caml_abs_float32")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.abs (local.get $x))))
++
++    (func (export "caml_modf_float32")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $a f32) (local $i f32) (local $f f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $a (f32.abs (local.get $x)))
++        (if (f32.ge (local.get $a) (f32.const 0))
++            (then
++            (if (f32.lt (local.get $a) (f32.const inf))
++                (then ;; normal
++                    (local.set $i (f32.floor (local.get $a)))
++                    (local.set $f (f32.sub (local.get $a) (local.get $i)))
++                    (local.set $i (f32.copysign (local.get $i) (local.get $x)))
++                    (local.set $f (f32.copysign (local.get $f) (local.get $x))))
++                (else ;; infinity
++                    (local.set $i (local.get $x))
++                    (local.set $f (f32.copysign (f32.const 0) (local.get $x))))))
++            (else ;; zero or nan
++            (local.set $i (local.get $x))
++            (local.set $f (local.get $x))))
++        (array.new_fixed $block 3 (ref.i31 (i32.const 0))
++            (call $box_float32 (local.get $f)) (call $box_float32 (local.get $i))))
++
++    (func (export "caml_fmod_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f64) (local $y f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (local.set $y (f64.promote_f32 (call $unbox_float32 (local.get 1))))
++        (call $box_float32 (f32.demote_f64 (call $fmod (local.get $x) (local.get $y)))))
++
++    (func (export "caml_acos_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $acos (local.get $x)))))
++
++    (func (export "caml_asin_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $asin (local.get $x)))))
++
++    (func (export "caml_atan_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $atan (local.get $x)))))
++
++    (func (export "caml_atan2_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f64) (local $y f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (local.set $y (f64.promote_f32 (call $unbox_float32 (local.get 1))))
++        (call $box_float32 (f32.demote_f64 (call $atan2 (local.get $x) (local.get $y)))))
++
++    (func (export "caml_ceil_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.ceil (local.get $x))))
++
++    (func (export "caml_floor_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.floor (local.get $x))))
++
++    (func (export "caml_exp_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $exp (local.get $x)))))
++
++    (func (export "caml_log_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $log (local.get $x)))))
++
++    (func (export "caml_power_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f64) (local $y f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (local.set $y (f64.promote_f32 (call $unbox_float32 (local.get 1))))
++        (call $box_float32 (f32.demote_f64 (call $pow (local.get $x) (local.get $y)))))
++
++    (func (export "caml_cos_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $cos (local.get $x)))))
++
++    (func (export "caml_sin_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $sin (local.get $x)))))
++
++    (func (export "caml_tan_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $tan (local.get $x)))))
++
++    (func (export "caml_sqrt_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.sqrt (local.get $x))))
++
++    (func (export "caml_nextafter_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32) (local $i i32) (local $j i32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (if (f32.ne (local.get $x) (local.get $x)) (then (return (local.get 0))))
++        (if (f32.ne (local.get $y) (local.get $y)) (then (return (local.get 1))))
++        (if (f32.eq (local.get $x) (local.get $y))
++            (then (return (local.get 1))))
++        (if (result (ref eq)) (f32.eq (local.get $x) (f32.const 0))
++            (then
++            (if (f32.ge (local.get $y) (f32.const 0))
++                (then (return (call $box_float32 (f32.const 0x1p-149))))
++                (else (return (call $box_float32 (f32.const -0x1p-149))))))
++            (else
++            (local.set $i (i32.reinterpret_f32 (local.get $x)))
++            (local.set $j (i32.reinterpret_f32 (local.get $y)))
++            (if (i32.and (i32.lt_s (local.get $i) (local.get $j))
++                         (i32.lt_u (local.get $i) (local.get $j)))
++                (then (local.set $i (i32.add (local.get $i) (i32.const 1))))
++                (else (local.set $i (i32.sub (local.get $i) (i32.const 1)))))
++            (return (call $box_float32 (f32.reinterpret_i32 (local.get $i)))))))
++
++    (func (export "caml_trunc_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.trunc (local.get $x))))
++
++    (func (export "caml_classify_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $a f32)
++        (local.set $a
++            (f32.abs (call $unbox_float32 (local.get 0))))
++        (ref.i31
++            (if (result i32) (f32.ge (local.get $a) (f32.const 0x1p-126))
++            (then
++                (if (result i32) (f32.lt (local.get $a) (f32.const inf))
++                    (then (i32.const 0)) ;; normal
++                    (else (i32.const 3)))) ;; infinity
++            (else
++                (if (result i32) (f32.eq (local.get $a) (f32.const 0))
++                    (then (i32.const 2)) ;; zero
++                    (else
++                        (if (result i32) (f32.eq (local.get $a) (local.get $a))
++                        (then (i32.const 1)) ;; subnormal
++                        (else (i32.const 4))))))))) ;; nan
++
++    (func (export "caml_ldexp_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_float32_of_float
++            (call $box_float
++                (call $caml_ldexp_float
++                    (call $unbox_float (call $caml_float_of_float32 (local.get 0)))
++                    (local.get 1)))))
++
++    (func (export "caml_frexp_float32")
++        (param (ref eq)) (result (ref eq))
++        (local $frexp (ref $block))
++        (local.set $frexp (ref.cast (ref $block)
++            (call $caml_frexp_float (call $caml_float_of_float32 (local.get 0)))))
++        (array.new_fixed $block 3 (ref.i31 (i32.const 0))
++            (call $caml_float32_of_float (array.get $block (local.get $frexp) (i32.const 1)))
++            (array.get $block (local.get $frexp) (i32.const 2))))
++
++    (func (export "caml_copysign_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (call $box_float32 (f32.copysign (local.get $x) (local.get $y))))
++
++    (func (export "caml_signbit_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (ref.i31 (i32.shr_u
++            (i32.reinterpret_f32 (call $unbox_float32 (local.get 0)))
++            (i32.const 31))))
++
++    (func (export "caml_expm1_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $expm1 (local.get $x)))))
++
++    (func (export "caml_exp2_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $pow (f64.const 2) (local.get $x)))))
++
++    (func (export "caml_log1p_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $log1p (local.get $x)))))
++
++    (func (export "caml_log2_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $log2 (local.get $x)))))
++
++    (func (export "caml_log10_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $log10 (local.get $x)))))
++
++    (func (export "caml_cosh_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $cosh (local.get $x)))))
++
++    (func (export "caml_acosh_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $acosh (local.get $x)))))
++
++    (func (export "caml_sinh_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $sinh (local.get $x)))))
++
++    (func (export "caml_asinh_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $asinh (local.get $x)))))
++
++    (func (export "caml_tanh_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $tanh (local.get $x)))))
++
++    (func (export "caml_atanh_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $atanh (local.get $x)))))
++
++    (func (export "caml_round_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.nearest (local.get $x))))
++
++    (func (export "caml_cbrt_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (call $box_float32 (f32.demote_f64 (call $cbrt (local.get $x)))))
++
++    (func (export "caml_erf_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x (ref eq))
++        (local.set $x (call $box_float (f64.promote_f32 (call $unbox_float32 (local.get 0)))))
++        (call $box_float32 (f32.demote_f64
++             (call $caml_erf_float (call $unbox_float (local.get $x))))))
++
++    (func (export "caml_erfc_float32_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x (ref eq))
++        (local.set $x (call $box_float (f64.promote_f32 (call $unbox_float32 (local.get 0)))))
++        (call $box_float32 (f32.demote_f64
++            (call $caml_erfc_float (call $unbox_float (local.get $x))))))
++
++    (func (export "caml_hypot_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f64) (local $y f64)
++        (local.set $x (f64.promote_f32 (call $unbox_float32 (local.get 0))))
++        (local.set $y (f64.promote_f32 (call $unbox_float32 (local.get 1))))
++        (call $box_float32 (f32.demote_f64 (call $hypot (local.get $x) (local.get $y)))))
++
++    (func (export "caml_fma_float32_bytecode")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x (ref eq)) (local $y (ref eq)) (local $z (ref eq))
++        (local.set $x (call $box_float (f64.promote_f32 (call $unbox_float32 (local.get 0)))))
++        (local.set $y (call $box_float (f64.promote_f32 (call $unbox_float32 (local.get 1)))))
++        (local.set $z (call $box_float (f64.promote_f32 (call $unbox_float32 (local.get 2)))))
++        (call $box_float32 (f32.demote_f64
++            (call $unbox_float (call $caml_fma_float (local.get $x) (local.get $y) (local.get $z))))))
++
++    (func (export "caml_simd_float32_min_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (call $box_float32
++            (if (result f32) (f32.lt (local.get $x) (local.get $y))
++                (then (local.get $x))
++                (else (local.get $y)))))
++
++    (func (export "caml_simd_float32_max_bytecode")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (local $x f32) (local $y f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (local.set $y (call $unbox_float32 (local.get 1)))
++        (call $box_float32
++            (if (result f32) (f32.gt (local.get $x) (local.get $y))
++                (then (local.get $x))
++                (else (local.get $y)))))
++
++    (func (export "caml_simd_cast_float32_int64_bytecode")
++        (param $f (ref eq)) (result (ref eq))
++        (call $caml_copy_int64
++            (i64.trunc_sat_f32_s (call $unbox_float32 (local.get $f)))))
++
++    (func (export "caml_simd_float32_round_current_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.nearest (local.get $x))))
++
++    (func (export "caml_simd_float32_round_neg_inf_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.floor (local.get $x))))
++
++    (func (export "caml_simd_float32_round_pos_inf_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.ceil (local.get $x))))
++
++    (func (export "caml_simd_float32_round_towards_zero_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (local $x f32)
++        (local.set $x (call $unbox_float32 (local.get 0)))
++        (call $box_float32 (f32.trunc (local.get $x))))
++
++    (func (export "caml_make_unboxed_float32_vect_bytecode")
++        (param (ref eq)) (result (ref eq))
++        (call $caml_make_vect (local.get 0) (call $box_float32 (f32.const 0))))
++
++    (func (export "caml_ba_float32_get_1")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_float32_of_float (call $caml_ba_get_1 (local.get 0) (local.get 1))))
++
++    (func (export "caml_ba_float32_get_2")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_float32_of_float (call $caml_ba_get_2 (local.get 0) (local.get 1) (local.get 2))))
++
++    (func (export "caml_ba_float32_get_3")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_float32_of_float (call $caml_ba_get_3 (local.get 0) (local.get 1) (local.get 2) (local.get 3))))
++
++    (func (export "caml_ba_float32_set_1")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_ba_set_1 (local.get 0) (local.get 1) (call $caml_float_of_float32 (local.get 2))))
++
++    (func (export "caml_ba_float32_set_2")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_ba_set_2 (local.get 0) (local.get 1) (local.get 2) (call $caml_float_of_float32 (local.get 3))))
++
++    (func (export "caml_ba_float32_set_3")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_ba_set_3 (local.get 0) (local.get 1) (local.get 2) (local.get 3) (call $caml_float_of_float32 (local.get 4))))
++
++    (func (export "caml_ba_uint8_getf32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $box_float32 (f32.reinterpret_i32
++            (call $caml_ba_uint8_get32 (local.get 0) (local.get 1)))))
++
++    (func (export "caml_ba_uint8_setf32")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_ba_uint8_set32 (local.get 0) (local.get 1)
++            (i32.reinterpret_f32 (call $unbox_float32 (local.get 2)))))
++
++    (func (export "caml_string_getf32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $box_float32 (f32.reinterpret_i32
++            (call $caml_string_get32 (local.get 0) (local.get 1)))))
++
++    (func (export "caml_bytes_getf32")
++        (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $box_float32 (f32.reinterpret_i32
++            (call $caml_bytes_get32 (local.get 0) (local.get 1)))))
++
++    (func (export "caml_bytes_setf32")
++        (param (ref eq)) (param (ref eq)) (param (ref eq)) (result (ref eq))
++        (call $caml_bytes_set32 (local.get 0) (local.get 1)
++            (i32.reinterpret_f32 (call $unbox_float32 (local.get 2)))))
++)

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-floatarray_create_local.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-floatarray_create_local.patch
@@ -1,0 +1,25 @@
+--- a/runtime/js/array.js
++++ b/runtime/js/array.js
+@@ -141,6 +141,12 @@
+   return b;
+ }
+
++//Provides: caml_floatarray_create_local const (const)
++//Requires: caml_floatarray_create
++function caml_floatarray_create_local(x) {
++  return caml_floatarray_create(x);
++}
++
+ // Provides: caml_iarray_of_array const
+ function caml_iarray_of_array(a) {
+   return a;
+--- a/runtime/wasm/array.wat
++++ b/runtime/wasm/array.wat
+@@ -52,6 +52,7 @@
+       (array.new $float_array (local.get $f) (local.get $sz)))
+
+    (func $caml_floatarray_create
++      (export "caml_floatarray_create_local")
+       (export "caml_make_float_vect") (export "caml_floatarray_create")
+       (export "caml_array_create_float")
+       (param $n (ref eq)) (result (ref eq))

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-gc-channel-objects.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-gc-channel-objects.patch
@@ -1,0 +1,936 @@
+--- a/runtime/io.js
++++ b/runtime/io.js
+@@ -25,12 +25,17 @@
+ //Provides: caml_sys_close
+ //Requires: caml_sys_fds
+ function caml_sys_close(fd) {
+-  var file = caml_sys_fds[fd];
+-  if (file) file.close();
++  var x = caml_sys_fds[fd];
++  if(x && x.file) x.file.close();
+   delete caml_sys_fds[fd];
+   return 0;
+ }
+
++//Provides: MlChanid
++function MlChanid(id){
++  this.id = id
++}
++
+ //Provides: caml_sys_open
+ //Requires: caml_raise_sys_error
+ //Requires: MlFakeFd_out
+@@ -39,224 +44,222 @@
+ //Requires: fs_node_supported
+ //Requires: caml_sys_fds
+ //Requires: caml_sys_open_for_node
+-function caml_sys_open_internal(file, idx) {
+-  if (idx == undefined) {
++//Requires: MlChanid
++function caml_sys_open_internal(file,idx) {
++  var chanid;
++  if(idx == undefined){
+     idx = caml_sys_fds.length;
++    chanid = new MlChanid(idx);
+   }
+-  caml_sys_fds[idx] = file;
++  else if(caml_sys_fds[idx]){
++    chanid = caml_sys_fds[idx].chanid;
++  }
++  else
++    chanid = new MlChanid(idx);
++  caml_sys_fds[idx] = {file:file, chanid: chanid};
+   return idx | 0;
+ }
+-function caml_sys_open(name, flags, _perms) {
++function caml_sys_open (name, flags, _perms) {
+   var f = {};
+-  while (flags) {
+-    switch (flags[1]) {
+-      case 0:
+-        f.rdonly = 1;
+-        break;
+-      case 1:
+-        f.wronly = 1;
+-        break;
+-      case 2:
+-        f.append = 1;
+-        break;
+-      case 3:
+-        f.create = 1;
+-        break;
+-      case 4:
+-        f.truncate = 1;
+-        break;
+-      case 5:
+-        f.excl = 1;
+-        break;
+-      case 6:
+-        f.binary = 1;
+-        break;
+-      case 7:
+-        f.text = 1;
+-        break;
+-      case 8:
+-        f.nonblock = 1;
+-        break;
++  while(flags){
++    switch(flags[1]){
++    case 0: f.rdonly = 1;break;
++    case 1: f.wronly = 1;break;
++    case 2: f.append = 1;break;
++    case 3: f.create = 1;break;
++    case 4: f.truncate = 1;break;
++    case 5: f.excl = 1; break;
++    case 6: f.binary = 1;break;
++    case 7: f.text = 1;break;
++    case 8: f.nonblock = 1;break;
+     }
+-    flags = flags[2];
++    flags=flags[2];
+   }
+-  if (f.rdonly && f.wronly)
+-    caml_raise_sys_error(
+-      caml_jsbytes_of_string(name) +
+-        " : flags Open_rdonly and Open_wronly are not compatible",
+-    );
+-  if (f.text && f.binary)
+-    caml_raise_sys_error(
+-      caml_jsbytes_of_string(name) +
+-        " : flags Open_text and Open_binary are not compatible",
+-    );
++  if(f.rdonly && f.wronly)
++    caml_raise_sys_error(caml_jsbytes_of_string(name) + " : flags Open_rdonly and Open_wronly are not compatible");
++  if(f.text && f.binary)
++    caml_raise_sys_error(caml_jsbytes_of_string(name) + " : flags Open_text and Open_binary are not compatible");
+   var root = resolve_fs_device(name);
+-  var file = root.device.open(root.rest, f);
+-  return caml_sys_open_internal(file, undefined);
++  var file = root.device.open(root.rest,f);
++  return caml_sys_open_internal (file, undefined);
+ }
+ (function () {
+   function file(fd, flags) {
+-    if (fs_node_supported()) {
++    if(fs_node_supported()) {
+       return caml_sys_open_for_node(fd, flags);
+-    } else return new MlFakeFd_out(fd, flags);
++    }
++    else
++      return new MlFakeFd_out(fd, flags)
+   }
+-  caml_sys_open_internal(
+-    file(0, { rdonly: 1, altname: "/dev/stdin", isCharacterDevice: true }),
+-    0,
+-  );
+-  caml_sys_open_internal(
+-    file(1, { buffered: 2, wronly: 1, isCharacterDevice: true }),
+-    1,
+-  );
+-  caml_sys_open_internal(
+-    file(2, { buffered: 2, wronly: 1, isCharacterDevice: true }),
+-    2,
+-  );
+-})();
++  caml_sys_open_internal(file(0,{rdonly:1,altname:"/dev/stdin",isCharacterDevice:true}), 0);
++  caml_sys_open_internal(file(1,{buffered:2,wronly:1,isCharacterDevice:true}), 1);
++  caml_sys_open_internal(file(2,{buffered:2,wronly:1,isCharacterDevice:true}), 2);
++})()
++
+
+ // ocaml Channels
+
+ //Provides: caml_ml_set_channel_name
+-//Requires: caml_ml_channel_get
++//Requires: caml_ml_channels
+ function caml_ml_set_channel_name(chanid, name) {
+-  var chan = caml_ml_channel_get(chanid);
++  var chan = caml_ml_channels.get(chanid);
+   chan.name = name;
+   return 0;
+ }
+
+ //Provides: caml_ml_channels
+-var caml_ml_channels = new Array();
++//Requires: MlChanid
++function caml_ml_channels_state() {
++  this.map = new globalThis.WeakMap ();
++  this.opened = new globalThis.Set();
++}
++caml_ml_channels_state.prototype.close = function (chanid) {
++  this.opened.delete(chanid);
++}
++caml_ml_channels_state.prototype.get = function (chanid) {
++  return this.map.get(chanid);
++}
++caml_ml_channels_state.prototype.set = function (chanid, val) {
++  if(val.opened) this.opened.add(chanid);
++  return this.map.set(chanid,val);
++}
++caml_ml_channels_state.prototype.all = function () {
++  return this.opened.values();
++}
++
++var caml_ml_channels = new caml_ml_channels_state;
+
+ //Provides: caml_ml_channel_redirect
+-//Requires: caml_ml_channel_get, caml_ml_channels
+-function caml_ml_channel_redirect(captured, into) {
+-  var to_restore = caml_ml_channel_get(captured);
+-  var new_ = caml_ml_channel_get(into);
+-  caml_ml_channels[captured] = new_; // XXX
++//Requires: caml_ml_channels
++function caml_ml_channel_redirect (captured, into){
++  var to_restore = caml_ml_channels.get(captured);
++  var new_ = caml_ml_channels.get(into);
++  caml_ml_channels.set(captured, new_);
+   return to_restore;
+ }
+
+ //Provides: caml_ml_channel_restore
+ //Requires: caml_ml_channels
+-function caml_ml_channel_restore(captured, to_restore) {
+-  caml_ml_channels[captured] = to_restore; // XXX
++function caml_ml_channel_restore (captured, to_restore){
++  caml_ml_channels.set(captured, to_restore);
+   return 0;
+ }
+
+ //Provides: caml_ml_channel_get
+ //Requires: caml_ml_channels
+ function caml_ml_channel_get(id) {
+-  return caml_ml_channels[id]; // XXX
++  return caml_ml_channels.get(id);
+ }
+
+ //Provides: caml_ml_out_channels_list
+ //Requires: caml_ml_channels
+-function caml_ml_out_channels_list() {
++//Requires: caml_sys_fds
++function caml_ml_out_channels_list () {
+   var l = 0;
+-  for (var c = 0; c < caml_ml_channels.length; c++) {
+-    if (
+-      caml_ml_channels[c] &&
+-      caml_ml_channels[c].opened &&
+-      caml_ml_channels[c].out
+-    )
+-      l = [0, caml_ml_channels[c].fd, l];
++  var keys = caml_ml_channels.all();
++  for(var k of keys){
++    var chan = caml_ml_channels.get(k);
++    if(chan.opened && chan.out) l=[0,k,l];
+   }
+   return l;
+ }
+
++
+ //Provides: caml_ml_open_descriptor_out
+ //Requires: caml_ml_channels, caml_sys_fds
+ //Requires: caml_raise_sys_error
+ //Requires: caml_sys_open
+-function caml_ml_open_descriptor_out(fd) {
+-  var file = caml_sys_fds[fd];
+-  if (file.flags.rdonly) caml_raise_sys_error("fd " + fd + " is readonly");
+-  var buffered = file.flags.buffered !== undefined ? file.flags.buffered : 1;
++function caml_ml_open_descriptor_out (fd) {
++  var s = caml_sys_fds[fd], file = s.file, chanid = s.chanid;
++  if(file.flags.rdonly) caml_raise_sys_error("fd "+ fd + " is readonly");
++  var buffered = (file.flags.buffered !== undefined) ? file.flags.buffered : 1;
+   var channel = {
+-    file: file,
+-    offset: file.flags.append ? file.length() : 0,
+-    fd: fd,
+-    opened: true,
+-    out: true,
+-    buffer_curr: 0,
+-    buffer: new Uint8Array(65536),
+-    buffered: buffered,
++    file:file,
++    offset:file.flags.append?file.length():0,
++    fd:fd,
++    opened:true,
++    out:true,
++    buffer_curr:0,
++    buffer:new Uint8Array(65536),
++    buffered:buffered
+   };
+-  caml_ml_channels[channel.fd] = channel;
+-  return channel.fd;
++  caml_ml_channels.set(chanid, channel);
++  return chanid;
+ }
+
+ //Provides: caml_ml_open_descriptor_in
+ //Requires: caml_ml_channels, caml_sys_fds
+ //Requires: caml_raise_sys_error
+ //Requires: caml_sys_open
+-function caml_ml_open_descriptor_in(fd) {
+-  var file = caml_sys_fds[fd];
+-  if (file.flags.wronly) caml_raise_sys_error("fd " + fd + " is writeonly");
++function caml_ml_open_descriptor_in (fd)  {
++  var s = caml_sys_fds[fd], file = s.file, chanid = s.chanid;
++  if(file.flags.wronly) caml_raise_sys_error("fd "+ fd + " is writeonly");
+   var refill = null;
+   var channel = {
+-    file: file,
+-    offset: file.flags.append ? file.length() : 0,
+-    fd: fd,
+-    opened: true,
++    file:file,
++    offset:file.flags.append?file.length():0,
++    fd:fd,
++    opened:true,
+     out: false,
+-    buffer_curr: 0,
+-    buffer_max: 0,
+-    buffer: new Uint8Array(65536),
+-    refill: refill,
++    buffer_curr:0,
++    buffer_max:0,
++    buffer:new Uint8Array(65536),
++    refill:refill
+   };
+-  caml_ml_channels[channel.fd] = channel;
+-  return channel.fd;
++  caml_ml_channels.set(chanid, channel);
++  return chanid;
+ }
+
++
+ //Provides: caml_ml_open_descriptor_in_with_flags
+ //Requires: caml_ml_open_descriptor_in
+ //Version: >= 5.1
+-function caml_ml_open_descriptor_in_with_flags(fd, flags) {
++function caml_ml_open_descriptor_in_with_flags(fd, flags){
+   return caml_ml_open_descriptor_in(fd);
+ }
+
+ //Provides: caml_ml_open_descriptor_out_with_flags
+ //Requires: caml_ml_open_descriptor_out
+ //Version: >= 5.1
+-function caml_ml_open_descriptor_out_with_flags(fd, flags) {
++function caml_ml_open_descriptor_out_with_flags(fd, flags){
+   return caml_ml_open_descriptor_out(fd);
+ }
+
+ //Provides: caml_channel_descriptor
+-//Requires: caml_ml_channel_get
++//Requires: caml_ml_channels
+ //Alias: win_filedescr_of_channel
+-function caml_channel_descriptor(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
++function caml_channel_descriptor(chanid){
++  var chan = caml_ml_channels.get(chanid);
+   return chan.fd;
+ }
+
+ //Provides: caml_ml_set_binary_mode
+-//Requires: caml_ml_channel_get
+-function caml_ml_set_binary_mode(chanid, mode) {
+-  var chan = caml_ml_channel_get(chanid);
+-  chan.file.flags.text = !mode;
+-  chan.file.flags.binary = mode;
++//Requires: caml_ml_channels
++function caml_ml_set_binary_mode(chanid,mode){
++  var chan = caml_ml_channels.get(chanid);
++  chan.file.flags.text = !mode
++  chan.file.flags.binary = mode
+   return 0;
+ }
+
+ //Provides: caml_ml_is_binary_mode
+-//Requires: caml_ml_channel_get
++//Requires: caml_ml_channels
+ //Version: >= 5.2
+ function caml_ml_is_binary_mode(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
+-  return chan.file.flags.binary;
++  var chan = caml_ml_channels.get(chanid);
++  return chan.file.flags.binary
+ }
+
+ //Input from in_channel
+
+ //Provides: caml_ml_close_channel
+-//Requires: caml_ml_flush, caml_ml_channel_get
++//Requires: caml_ml_flush, caml_ml_channels
+ //Requires: caml_sys_close
+-function caml_ml_close_channel(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
+-  if (chan.opened) {
++function caml_ml_close_channel (chanid) {
++  var chan = caml_ml_channels.get(chanid);
++  if(chan.opened) {
+     chan.opened = false;
++    caml_ml_channels.close(chanid);
+     caml_sys_close(chan.fd);
+     chan.fd = -1;
+     chan.buffer = new Uint8Array(0);
+@@ -267,61 +270,55 @@
+ }
+
+ //Provides: caml_ml_channel_size
+-//Requires: caml_ml_channel_get
++//Requires: caml_ml_channels
+ function caml_ml_channel_size(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
++  var chan = caml_ml_channels.get(chanid);
+   return chan.file.length();
+ }
+
+ //Provides: caml_ml_channel_size_64
+-//Requires: caml_int64_of_float,caml_ml_channel_get
++//Requires: caml_int64_of_float,caml_ml_channels
+ function caml_ml_channel_size_64(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
+-  return caml_int64_of_float(chan.file.length());
++  var chan = caml_ml_channels.get(chanid);
++  return caml_int64_of_float(chan.file.length ());
+ }
+
+ //Provides: caml_ml_set_channel_output
+-//Requires: caml_ml_channel_get
+-function caml_ml_set_channel_output(chanid, f) {
+-  var chan = caml_ml_channel_get(chanid);
+-  chan.output = function (s) {
+-    f(s);
+-  };
++//Requires: caml_ml_channels
++function caml_ml_set_channel_output(chanid,f) {
++  var chan = caml_ml_channels.get(chanid);
++  chan.output = (function (s) {f(s)});
+   return 0;
+ }
+
+ //Provides: caml_ml_set_channel_refill
+-//Requires: caml_ml_channel_get
+-function caml_ml_set_channel_refill(chanid, f) {
+-  caml_ml_channel_get(chanid).refill = f;
++//Requires: caml_ml_channels
++function caml_ml_set_channel_refill(chanid,f) {
++  caml_ml_channels.get(chanid).refill = f;
+   return 0;
+ }
+
+ //Provides: caml_refill
+ //Requires: caml_ml_string_length, caml_uint8_array_of_string
+-function caml_refill(chan) {
+-  if (chan.refill != null) {
++function caml_refill (chan) {
++  if(chan.refill != null){
+     var str = chan.refill();
+     var str_a = caml_uint8_array_of_string(str);
+     if (str_a.length == 0) {
+-      chan.refill = null;
+-    } else {
+-      if (chan.buffer.length < chan.buffer_max + str_a.length) {
++      chan.refill = null
++    }
++    else {
++      if(chan.buffer.length < chan.buffer_max + str_a.length){
+         var b = new Uint8Array(chan.buffer_max + str_a.length);
+         b.set(chan.buffer);
+         chan.buffer = b;
+       }
+-      chan.buffer.set(str_a, chan.buffer_max);
++      chan.buffer.set(str_a,chan.buffer_max);
+       chan.offset += str_a.length;
+       chan.buffer_max += str_a.length;
+     }
+   } else {
+-    var nread = chan.file.read(
+-      chan.offset,
+-      chan.buffer,
+-      chan.buffer_max,
+-      chan.buffer.length - chan.buffer_max,
+-    );
++    var nread = chan.file.read(chan.offset, chan.buffer, chan.buffer_max, chan.buffer.length - chan.buffer_max);
+     chan.offset += nread;
+     chan.buffer_max += nread;
+   }
+@@ -330,30 +327,31 @@
+ //Provides: caml_ml_input
+ //Requires: caml_ml_input_block
+ //Requires: caml_uint8_array_of_bytes
+-function caml_ml_input(chanid, b, i, l) {
++function caml_ml_input (chanid, b, i, l) {
+   var ba = caml_uint8_array_of_bytes(b);
+-  return caml_ml_input_block(chanid, ba, i, l);
++  return caml_ml_input_block(chanid, ba, i, l)
+ }
+
+ //Provides: caml_ml_input_bigarray
+ //Requires: caml_ml_input_block
+ //Requires: caml_ba_to_typed_array
+-function caml_ml_input_bigarray(chanid, b, i, l) {
++function caml_ml_input_bigarray (chanid, b, i, l) {
+   var ba = caml_ba_to_typed_array(b);
+-  return caml_ml_input_block(chanid, ba, i, l);
++  return caml_ml_input_block(chanid, ba, i, l)
+ }
+
+ //Provides: caml_ml_input_block
+-//Requires: caml_refill, caml_ml_channel_get
+-function caml_ml_input_block(chanid, ba, i, l) {
+-  var chan = caml_ml_channel_get(chanid);
++//Requires: caml_refill, caml_ml_channels
++function caml_ml_input_block (chanid, ba, i, l) {
++  var chan = caml_ml_channels.get(chanid);
+   var n = l;
+   var avail = chan.buffer_max - chan.buffer_curr;
+-  if (l <= avail) {
+-    ba.set(chan.buffer.subarray(chan.buffer_curr, chan.buffer_curr + l), i);
++  if(l <= avail) {
++    ba.set(chan.buffer.subarray(chan.buffer_curr,chan.buffer_curr + l), i);
+     chan.buffer_curr += l;
+-  } else if (avail > 0) {
+-    ba.set(chan.buffer.subarray(chan.buffer_curr, chan.buffer_curr + avail), i);
++  }
++  else if(avail > 0) {
++    ba.set(chan.buffer.subarray(chan.buffer_curr,chan.buffer_curr + avail), i);
+     chan.buffer_curr += avail;
+     n = avail;
+   } else {
+@@ -361,45 +359,50 @@
+     chan.buffer_max = 0;
+     caml_refill(chan);
+     var avail = chan.buffer_max - chan.buffer_curr;
+-    if (n > avail) n = avail;
+-    ba.set(chan.buffer.subarray(chan.buffer_curr, chan.buffer_curr + n), i);
++    if(n > avail) n = avail;
++    ba.set(chan.buffer.subarray(chan.buffer_curr,chan.buffer_curr + n), i);
+     chan.buffer_curr += n;
+   }
+   return n | 0;
+ }
+
+ //Provides: caml_input_value
+-//Requires: caml_marshal_data_size, caml_input_value_from_bytes, caml_create_bytes, caml_ml_channel_get, caml_bytes_of_array
++//Requires: caml_marshal_data_size, caml_input_value_from_bytes, caml_create_bytes, caml_ml_channels, caml_bytes_of_array
+ //Requires: caml_refill, caml_failwith, caml_raise_end_of_file
+ //Requires: caml_marshal_header_size
+-function caml_input_value(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
++function caml_input_value (chanid) {
++  var chan = caml_ml_channels.get(chanid);
+   var header = new Uint8Array(caml_marshal_header_size);
+   function block(buffer, offset, n) {
+     var r = 0;
+-    while (r < n) {
+-      if (chan.buffer_curr >= chan.buffer_max) {
++    while(r < n){
++      if(chan.buffer_curr >= chan.buffer_max){
+         chan.buffer_curr = 0;
+         chan.buffer_max = 0;
+         caml_refill(chan);
+       }
+-      if (chan.buffer_curr >= chan.buffer_max) break;
+-      buffer[offset + r] = chan.buffer[chan.buffer_curr];
++      if (chan.buffer_curr >= chan.buffer_max)
++        break;
++      buffer[offset+r] = chan.buffer[chan.buffer_curr];
+       chan.buffer_curr++;
+       r++;
+     }
+     return r;
+   }
+   var r = block(header, 0, caml_marshal_header_size);
+-  if (r == 0) caml_raise_end_of_file();
++  if(r == 0)
++    caml_raise_end_of_file();
+   else if (r < caml_marshal_header_size)
+     caml_failwith("input_value: truncated object");
+-  var len = caml_marshal_data_size(caml_bytes_of_array(header), 0);
++  var len = caml_marshal_data_size (caml_bytes_of_array(header), 0);
+   var buf = new Uint8Array(len + caml_marshal_header_size);
+-  buf.set(header, 0);
+-  var r = block(buf, caml_marshal_header_size, len);
+-  if (r < len) caml_failwith("input_value: truncated object " + r + "  " + len);
+-  var res = caml_input_value_from_bytes(caml_bytes_of_array(buf), 0);
++  buf.set(header,0);
++  var r = block(buf, caml_marshal_header_size, len)
++  if(r < len)
++    caml_failwith("input_value: truncated object " + r + "  " + len);
++  var offset = [0];
++  var res = caml_input_value_from_bytes(caml_bytes_of_array(buf), offset);
++  chan.offset = chan.offset + offset[0];
+   return res;
+ }
+
+@@ -411,15 +414,16 @@
+
+ //Provides: caml_ml_input_char
+ //Requires: caml_raise_end_of_file, caml_array_bound_error
+-//Requires: caml_ml_channel_get, caml_refill
+-function caml_ml_input_char(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
+-  if (chan.buffer_curr >= chan.buffer_max) {
++//Requires: caml_ml_channels, caml_refill
++function caml_ml_input_char (chanid) {
++  var chan = caml_ml_channels.get(chanid);
++  if(chan.buffer_curr >= chan.buffer_max){
+     chan.buffer_curr = 0;
+     chan.buffer_max = 0;
+     caml_refill(chan);
+   }
+-  if (chan.buffer_curr >= chan.buffer_max) caml_raise_end_of_file();
++  if (chan.buffer_curr >= chan.buffer_max)
++    caml_raise_end_of_file();
+   var res = chan.buffer[chan.buffer_curr];
+   chan.buffer_curr++;
+   return res;
+@@ -427,26 +431,24 @@
+
+ //Provides: caml_ml_input_int
+ //Requires: caml_raise_end_of_file
+-//Requires: caml_ml_input_char, caml_ml_channel_get
+-function caml_ml_input_int(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
++//Requires: caml_ml_input_char, caml_ml_channels
++function caml_ml_input_int (chanid) {
++  var chan = caml_ml_channels.get(chanid);
+   var res = 0;
+-  for (var i = 0; i < 4; i++) {
+-    res = ((res << 8) + caml_ml_input_char(chanid)) | 0;
++  for(var i = 0; i < 4; i++){
++    res = (res << 8) + caml_ml_input_char(chanid) | 0;
+   }
+   return res | 0;
+ }
+
+ //Provides: caml_seek_in
+-//Requires: caml_raise_sys_error, caml_ml_channel_get
++//Requires: caml_raise_sys_error, caml_ml_channels
+ function caml_seek_in(chanid, pos) {
+-  var chan = caml_ml_channel_get(chanid);
++  var chan = caml_ml_channels.get(chanid);
+   if (chan.refill != null) caml_raise_sys_error("Illegal seek");
+-  if (
+-    pos >= chan.offset - chan.buffer_max &&
+-    pos <= chan.offset &&
+-    chan.file.flags.binary
+-  ) {
++  if(pos >= chan.offset - chan.buffer_max
++     && pos <= chan.offset
++     && chan.file.flags.binary) {
+     chan.buffer_curr = chan.buffer_max - (chan.offset - pos);
+   } else {
+     chan.offset = pos;
+@@ -458,22 +460,22 @@
+
+ //Provides: caml_ml_seek_in
+ //Requires: caml_seek_in
+-function caml_ml_seek_in(chanid, pos) {
+-  return caml_seek_in(chanid, pos);
++function caml_ml_seek_in(chanid,pos){
++  return caml_seek_in(chanid,pos);
+ }
+
+ //Provides: caml_ml_seek_in_64
+ //Requires: caml_int64_to_float, caml_seek_in
+-function caml_ml_seek_in_64(chanid, pos) {
++function caml_ml_seek_in_64(chanid,pos){
+   var pos = caml_int64_to_float(pos);
+   return caml_seek_in(chanid, pos);
+ }
+
+ //Provides: caml_pos_in
+-//Requires: caml_ml_channel_get
++//Requires: caml_ml_channels
+ function caml_pos_in(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
+-  return (chan.offset - (chan.buffer_max - chan.buffer_curr)) | 0;
++  var chan = caml_ml_channels.get(chanid);
++  return chan.offset - (chan.buffer_max - chan.buffer_curr) | 0;
+ }
+
+ //Provides: caml_ml_pos_in
+@@ -490,25 +492,25 @@
+
+ //Provides: caml_ml_input_scan_line
+ //Requires: caml_array_bound_error
+-//Requires: caml_ml_channel_get, caml_refill
+-function caml_ml_input_scan_line(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
++//Requires: caml_ml_channels, caml_refill
++function caml_ml_input_scan_line(chanid){
++  var chan = caml_ml_channels.get(chanid);
+   var p = chan.buffer_curr;
+   do {
+-    if (p >= chan.buffer_max) {
+-      if (chan.buffer_curr > 0) {
+-        chan.buffer.set(chan.buffer.subarray(chan.buffer_curr), 0);
++    if(p >= chan.buffer_max) {
++      if(chan.buffer_curr > 0) {
++        chan.buffer.set(chan.buffer.subarray(chan.buffer_curr),0);
+         p -= chan.buffer_curr;
+         chan.buffer_max -= chan.buffer_curr;
+         chan.buffer_curr = 0;
+       }
+-      if (chan.buffer_max >= chan.buffer.length) {
+-        return -chan.buffer_max | 0;
++      if(chan.buffer_max >= chan.buffer.length) {
++        return -(chan.buffer_max) | 0;
+       }
+       var prev_max = chan.buffer_max;
+-      caml_refill(chan);
+-      if (prev_max == chan.buffer_max) {
+-        return -chan.buffer_max | 0;
++      caml_refill (chan);
++      if(prev_max == chan.buffer_max) {
++        return -(chan.buffer_max) | 0;
+       }
+     }
+   } while (chan.buffer[p++] != 10);
+@@ -516,13 +518,13 @@
+ }
+
+ //Provides: caml_ml_flush
+-//Requires: caml_raise_sys_error, caml_ml_channel_get
++//Requires: caml_raise_sys_error, caml_ml_channels
+ //Requires: caml_subarray_to_jsbytes
+-function caml_ml_flush(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
+-  if (!chan.opened) caml_raise_sys_error("Cannot flush a closed channel");
+-  if (!chan.buffer || chan.buffer_curr == 0) return 0;
+-  if (chan.output) {
++function caml_ml_flush (chanid) {
++  var chan = caml_ml_channels.get(chanid);
++  if(! chan.opened) caml_raise_sys_error("Cannot flush a closed channel");
++  if(!chan.buffer || chan.buffer_curr == 0) return 0;
++  if(chan.output) {
+     chan.output(caml_subarray_to_jsbytes(chan.buffer, 0, chan.buffer_curr));
+   } else {
+     chan.file.write(chan.offset, chan.buffer, 0, chan.buffer_curr);
+@@ -536,113 +538,115 @@
+
+ //Provides: caml_ml_output_ta
+ //Requires: caml_ml_flush,caml_ml_bytes_length
+-//Requires: caml_raise_sys_error, caml_ml_channel_get
+-function caml_ml_output_ta(chanid, buffer, offset, len) {
+-  var chan = caml_ml_channel_get(chanid);
+-  if (!chan.opened) caml_raise_sys_error("Cannot output to a closed channel");
++//Requires: caml_raise_sys_error, caml_ml_channels
++function caml_ml_output_ta(chanid,buffer,offset,len) {
++  var chan = caml_ml_channels.get(chanid);
++  if(! chan.opened) caml_raise_sys_error("Cannot output to a closed channel");
+   buffer = buffer.subarray(offset, offset + len);
+-  if (chan.buffer_curr + buffer.length > chan.buffer.length) {
++  if(chan.buffer_curr + buffer.length > chan.buffer.length) {
+     var b = new Uint8Array(chan.buffer_curr + buffer.length);
+     b.set(chan.buffer);
+-    chan.buffer = b;
++    chan.buffer = b
+   }
+-  switch (chan.buffered) {
+-    case 0: // Unbuffered
++  switch(chan.buffered){
++  case 0: // Unbuffered
++    chan.buffer.set(buffer, chan.buffer_curr);
++    chan.buffer_curr += buffer.length;
++    caml_ml_flush (chanid);
++    break
++  case 1: // Buffered (the default)
++    chan.buffer.set(buffer, chan.buffer_curr);
++    chan.buffer_curr += buffer.length;
++    if(chan.buffer_curr >= chan.buffer.length)
++      caml_ml_flush (chanid);
++    break;
++  case 2: // Buffered (only for stdout and stderr)
++    var id = buffer.lastIndexOf(10)
++    if(id < 0) {
+       chan.buffer.set(buffer, chan.buffer_curr);
+       chan.buffer_curr += buffer.length;
+-      caml_ml_flush(chanid);
+-      break;
+-    case 1: // Buffered (the default)
+-      chan.buffer.set(buffer, chan.buffer_curr);
+-      chan.buffer_curr += buffer.length;
+-      if (chan.buffer_curr >= chan.buffer.length) caml_ml_flush(chanid);
+-      break;
+-    case 2: // Buffered (only for stdout and stderr)
+-      var id = buffer.lastIndexOf(10);
+-      if (id < 0) {
+-        chan.buffer.set(buffer, chan.buffer_curr);
+-        chan.buffer_curr += buffer.length;
+-        if (chan.buffer_curr >= chan.buffer.length) caml_ml_flush(chanid);
+-      } else {
+-        chan.buffer.set(buffer.subarray(0, id + 1), chan.buffer_curr);
+-        chan.buffer_curr += id + 1;
+-        caml_ml_flush(chanid);
+-        chan.buffer.set(buffer.subarray(id + 1), chan.buffer_curr);
+-        chan.buffer_curr += buffer.length - id - 1;
+-      }
+-      break;
++      if(chan.buffer_curr >= chan.buffer.length)
++        caml_ml_flush (chanid);
++    }
++    else {
++      chan.buffer.set(buffer.subarray(0, id + 1), chan.buffer_curr);
++      chan.buffer_curr += id + 1;
++      caml_ml_flush (chanid);
++      chan.buffer.set(buffer.subarray(id + 1), chan.buffer_curr);
++      chan.buffer_curr += buffer.length - id - 1;
++    }
++    break;
+   }
+   return 0;
+ }
+
+ //Provides: caml_ml_output_bytes
+ //Requires: caml_uint8_array_of_bytes, caml_ml_output_ta
+-function caml_ml_output_bytes(chanid, buffer, offset, len) {
++function caml_ml_output_bytes(chanid,buffer,offset,len) {
+   var buffer = caml_uint8_array_of_bytes(buffer);
+-  return caml_ml_output_ta(chanid, buffer, offset, len);
++  return caml_ml_output_ta(chanid,buffer,offset,len);
+ }
+
++
+ //Provides: caml_ml_output_bigarray
+ //Requires: caml_ba_to_typed_array, caml_ml_output_ta
+-function caml_ml_output_bigarray(chanid, buffer, offset, len) {
++function caml_ml_output_bigarray(chanid,buffer,offset,len) {
+   var buffer = caml_ba_to_typed_array(buffer);
+-  return caml_ml_output_ta(chanid, buffer, offset, len);
++  return caml_ml_output_ta(chanid,buffer,offset,len);
+ }
+
++
++
+ //Provides: caml_ml_output
+ //Requires: caml_ml_output_bytes, caml_bytes_of_string
+-function caml_ml_output(chanid, buffer, offset, len) {
+-  return caml_ml_output_bytes(
+-    chanid,
+-    caml_bytes_of_string(buffer),
+-    offset,
+-    len,
+-  );
++function caml_ml_output(chanid,buffer,offset,len){
++  return caml_ml_output_bytes(chanid,caml_bytes_of_string(buffer),offset,len);
+ }
+
+ //Provides: caml_ml_output_char
+ //Requires: caml_ml_output
+ //Requires: caml_string_of_jsbytes
+-function caml_ml_output_char(chanid, c) {
++function caml_ml_output_char (chanid,c) {
+   var s = caml_string_of_jsbytes(String.fromCharCode(c));
+-  caml_ml_output(chanid, s, 0, 1);
++  caml_ml_output(chanid,s,0,1);
+   return 0;
+ }
+
+ //Provides: caml_output_value
+ //Requires: caml_output_value_to_string, caml_ml_output,caml_ml_string_length
+-function caml_output_value(chanid, v, flags) {
++function caml_output_value (chanid,v,flags) {
+   var s = caml_output_value_to_string(v, flags);
+-  caml_ml_output(chanid, s, 0, caml_ml_string_length(s));
++  caml_ml_output(chanid,s,0,caml_ml_string_length(s));
+   return 0;
+ }
+
++
+ //Provides: caml_seek_out
+-//Requires: caml_ml_channel_get, caml_ml_flush
+-function caml_seek_out(chanid, pos) {
++//Requires: caml_ml_channels, caml_ml_flush
++function caml_seek_out(chanid, pos){
+   caml_ml_flush(chanid);
+-  var chan = caml_ml_channel_get(chanid);
++  var chan = caml_ml_channels.get(chanid);
+   chan.offset = pos;
+   return 0;
+ }
+
+ //Provides: caml_ml_seek_out
+ //Requires: caml_seek_out
+-function caml_ml_seek_out(chanid, pos) {
++function caml_ml_seek_out(chanid,pos){
+   return caml_seek_out(chanid, pos);
+ }
+ //Provides: caml_ml_seek_out_64
+ //Requires: caml_int64_to_float, caml_seek_out
+-function caml_ml_seek_out_64(chanid, pos) {
++function caml_ml_seek_out_64(chanid,pos){
+   var pos = caml_int64_to_float(pos);
+   return caml_seek_out(chanid, pos);
+ }
+
+ //Provides: caml_pos_out
+-//Requires: caml_ml_channel_get, caml_ml_flush
++//Requires: caml_ml_channels, caml_ml_flush
+ function caml_pos_out(chanid) {
+-  var chan = caml_ml_channel_get(chanid);
+-  return chan.offset + chan.buffer_curr;
++  var chan = caml_ml_channels.get(chanid);
++  return chan.offset + chan.buffer_curr
+ }
+
+ //Provides: caml_ml_pos_out
+@@ -654,29 +658,29 @@
+ //Provides: caml_ml_pos_out_64
+ //Requires: caml_int64_of_float, caml_pos_out
+ function caml_ml_pos_out_64(chanid) {
+-  return caml_int64_of_float(caml_pos_out(chanid));
++  return caml_int64_of_float (caml_pos_out(chanid));
+ }
+
+ //Provides: caml_ml_output_int
+ //Requires: caml_ml_output
+ //Requires: caml_string_of_array
+-function caml_ml_output_int(chanid, i) {
+-  var arr = [(i >> 24) & 0xff, (i >> 16) & 0xff, (i >> 8) & 0xff, i & 0xff];
++function caml_ml_output_int (chanid,i) {
++  var arr = [(i>>24) & 0xFF,(i>>16) & 0xFF,(i>>8) & 0xFF,i & 0xFF ];
+   var s = caml_string_of_array(arr);
+-  caml_ml_output(chanid, s, 0, 4);
+-  return 0;
++  caml_ml_output(chanid,s,0,4);
++  return 0
+ }
+
+ //Provides: caml_ml_is_buffered
+-//Requires: caml_ml_channel_get
++//Requires: caml_ml_channels
+ function caml_ml_is_buffered(chanid) {
+-  return caml_ml_channel_get(chanid).buffered ? 1 : 0;
++  return caml_ml_channels.get(chanid).buffered ? 1 : 0
+ }
+
+ //Provides: caml_ml_set_buffered
+-//Requires: caml_ml_channel_get, caml_ml_flush
+-function caml_ml_set_buffered(chanid, v) {
+-  caml_ml_channel_get(chanid).buffered = v;
+-  if (!v) caml_ml_flush(chanid);
+-  return 0;
+-}
++//Requires: caml_ml_channels, caml_ml_flush
++function caml_ml_set_buffered(chanid,v) {
++  caml_ml_channels.get(chanid).buffered = v;
++  if(!v) caml_ml_flush(chanid);
++  return 0
++}
+\ No newline at end of file
+--- a/runtime/parsing.js
++++ b/runtime/parsing.js
+@@ -24,6 +24,7 @@
+ //Requires: caml_lex_array, caml_parser_trace,caml_jsstring_of_string
+ //Requires: caml_ml_output, caml_ml_string_length, caml_string_of_jsbytes
+ //Requires: caml_jsbytes_of_string, MlBytes
++//Requires: caml_sys_fds
+ function caml_parse_engine(tables, env, cmd, arg) {
+   var ERRCODE = 256;
+
+@@ -82,7 +83,7 @@
+
+   function log(x) {
+     var s = caml_string_of_jsbytes(x + "\n");
+-    caml_ml_output(2, s, 0, caml_ml_string_length(s));
++    caml_ml_output(caml_sys_fds[2].chanid, s, 0, caml_ml_string_length(s));
+   }
+
+   function token_name(names, number) {

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-gh1482.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-gh1482.patch
@@ -1,0 +1,460 @@
+From 0e12ddb4a525a194348c47f028f0267fca800905 Mon Sep 17 00:00:00 2001
+From: Hugo Heuzard <hugo.heuzard@gmail.com>
+Date: Sun, 2 Jul 2023 13:26:44 +0200
+Subject: [PATCH 1/5] Tests: add test for gh 1481
+
+---
+ compiler/tests-compiler/dune.inc  |  15 ++++
+ compiler/tests-compiler/gh1481.ml | 132 ++++++++++++++++++++++++++++++
+ 2 files changed, 147 insertions(+)
+ create mode 100644 compiler/tests-compiler/gh1481.ml
+
+diff --git a/compiler/tests-compiler/gh1481.ml b/compiler/tests-compiler/gh1481.ml
+new file mode 100644
+index 0000000000..de75346bca
+--- /dev/null
++++ b/compiler/tests-compiler/gh1481.ml
+@@ -0,0 +1,132 @@
++let%expect_test _ =
++  let prog =
++    {|
++type test = [ `B | `C | `D | `A ]
++
++let to_string (tag : test) =
++  match tag with
++  | `A -> ("`A")
++  | `B -> ("`B")
++  | `C -> ("`C")
++  | `D -> ("`D")
++
++let correct x y =
++  let z =
++    match x, y with
++    | (`A, v) | (v, `A) -> v
++    | `B, _ | _, `B -> `B
++    | `C, _ | _, `C -> `C
++    | `D, `D -> `D
++  in
++  z
++
++let incorrect x y =
++  match x, y with
++  | (`A, v) | (v, `A) -> v
++  | `B, _ | _, `B -> `B
++  | `C, _ | _, `C -> `C
++  | `D, `D -> `D
++
++let () =
++  let a = `C in
++  Printf.printf "[a] is: %s\n" (to_string a);
++
++  let b = `A in
++  Printf.printf "[b] is: %s\n" (to_string b);
++
++  let c = correct a b in
++  Printf.printf "[correct a b] is: %s\n" (to_string c);
++
++  let d = incorrect a b in
++  Printf.printf "[incorrect a b] is: %s\n" (to_string d);
++
++  |}
++  in
++  let program = Util.compile_and_parse ~debug:false prog in
++  Util.print_program program;
++  [%expect
++    {|
++    (function(globalThis){
++       "use strict";
++       var
++        runtime = globalThis.jsoo_runtime,
++        caml_string_of_jsbytes = runtime.caml_string_of_jsbytes;
++       function caml_call2(f, a0, a1){
++        return (f.l >= 0 ? f.l : f.l = f.length) == 2
++                ? f(a0, a1)
++                : runtime.caml_call_gen(f, [a0, a1]);
++       }
++       var
++        global_data = runtime.caml_get_global_data(),
++        Stdlib_Printf = global_data.Stdlib__Printf,
++        cst_D = caml_string_of_jsbytes("`D"),
++        cst_C = caml_string_of_jsbytes("`C"),
++        cst_B = caml_string_of_jsbytes("`B"),
++        cst_A = caml_string_of_jsbytes("`A"),
++        _e_ =
++          [0,
++           [11, caml_string_of_jsbytes("[a] is: "), [2, 0, [12, 10, 0]]],
++           caml_string_of_jsbytes("[a] is: %s\n")],
++        _g_ =
++          [0,
++           [11, caml_string_of_jsbytes("[b] is: "), [2, 0, [12, 10, 0]]],
++           caml_string_of_jsbytes("[b] is: %s\n")],
++        _i_ =
++          [0,
++           [11, caml_string_of_jsbytes("[correct a b] is: "), [2, 0, [12, 10, 0]]],
++           caml_string_of_jsbytes("[correct a b] is: %s\n")],
++        _k_ =
++          [0,
++           [11,
++            caml_string_of_jsbytes("[incorrect a b] is: "),
++            [2, 0, [12, 10, 0]]],
++           caml_string_of_jsbytes("[incorrect a b] is: %s\n")];
++       function _a_(_r_){
++        return 67 <= _r_ ? 68 <= _r_ ? cst_D : cst_C : 66 <= _r_ ? cst_B : cst_A;
++       }
++       function _b_(_p_, _o_){
++        if(65 === _p_)
++         var _q_ = _o_;
++        else{
++         if(68 === _p_ && 68 === _o_) return 68;
++         if(65 !== _o_){
++          if(66 !== _o_ && 66 !== _p_){67 === _p_; return 67;}
++          return 66;
++         }
++         var _q_ = _p_;
++        }
++        return _q_;
++       }
++       function _c_(_m_, _l_){
++        if(65 === _m_)
++         var _n_ = _l_;
++        else{
++         if(68 === _m_ && 68 === _l_) return 68;
++         if(65 !== _l_){
++          if(66 !== _l_ && 66 !== _m_){67 === _m_; return 67;}
++          return 66;
++         }
++         var _n_ = _m_;
++        }
++        return _n_;
++       }
++       var _d_ = _a_(67);
++       caml_call2(Stdlib_Printf[2], _e_, _d_);
++       var _f_ = _a_(65);
++       caml_call2(Stdlib_Printf[2], _g_, _f_);
++       var _h_ = _a_(_b_(67, 65));
++       caml_call2(Stdlib_Printf[2], _i_, _h_);
++       var _j_ = _a_(_c_(67, 65));
++       caml_call2(Stdlib_Printf[2], _k_, _j_);
++       var Test = [0, _a_, _b_, _c_];
++       runtime.caml_register_global(9, Test, "Test");
++       return;
++      }
++      (globalThis));
++    //end |}];
++  Util.compile_and_run ~debug:false prog;
++  [%expect {|
++    [a] is: `C
++    [b] is: `A
++    [correct a b] is: `C
++    [incorrect a b] is: `C |}]
+
+From 40fbbcd3960d3ce00cc6c01f440a1908b7f20532 Mon Sep 17 00:00:00 2001
+From: Hugo Heuzard <hugo.heuzard@gmail.com>
+Date: Tue, 4 Jul 2023 00:17:28 +0200
+Subject: [PATCH 2/5] fix
+
+---
+ compiler/lib/generate.ml          |  7 ++-
+ compiler/tests-compiler/gh1481.ml | 73 +++++++++++++++++++++++--------
+ 2 files changed, 60 insertions(+), 20 deletions(-)
+
+diff --git a/compiler/lib/generate.ml b/compiler/lib/generate.ml
+index caef5e7462..1033262d09 100644
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -1698,8 +1698,11 @@ and compile_merge_node
+       let new_frontier =
+         members
+         |> List.map ~f:(fun pc ->
+-               let seen = get_seen st pc in
+-               dominance_frontier ~seen st pc)
++               if Addr.Set.mem pc frontier
++               then Addr.Set.singleton pc
++               else
++                 let seen = get_seen st pc in
++                 dominance_frontier ~seen st pc)
+         |> List.fold_left ~init:Addr.Set.empty ~f:Addr.Set.union
+       in
+       (* The frontier has to move when compiling a merge node. Fail early instead of infinite recursion. *)
+diff --git a/compiler/tests-compiler/gh1481.ml b/compiler/tests-compiler/gh1481.ml
+index de75346bca..279a269665 100644
+--- a/compiler/tests-compiler/gh1481.ml
++++ b/compiler/tests-compiler/gh1481.ml
+@@ -85,28 +85,64 @@ let () =
+         return 67 <= _r_ ? 68 <= _r_ ? cst_D : cst_C : 66 <= _r_ ? cst_B : cst_A;
+        }
+        function _b_(_p_, _o_){
+-        if(65 === _p_)
+-         var _q_ = _o_;
+-        else{
+-         if(68 === _p_ && 68 === _o_) return 68;
+-         if(65 !== _o_){
+-          if(66 !== _o_ && 66 !== _p_){67 === _p_; return 67;}
+-          return 66;
++        var switch$0 = 0;
++        if(typeof _p_ === "number")
++         if(65 === _p_){
++          var _q_ = _o_;
++          switch$0 = 1;
+          }
+-         var _q_ = _p_;
++         else if(68 === _p_ && typeof _o_ === "number" && 68 === _o_) return 68;
++        if(! switch$0){
++         var switch$1 = 0;
++         if(typeof _o_ === "number")
++          if(65 === _o_){
++           var _q_ = _p_;
++           switch$1 = 2;
++          }
++          else if(66 === _o_) switch$1 = 1;
++         var switch$2 = 0;
++         switch(switch$1){
++           case 0:
++            var switch$3 = 0;
++            if(typeof _p_ === "number")
++             if(66 === _p_) switch$3 = 1; else 67 === _p_;
++            if(! switch$3) return 67;
++            break;
++           case 2:
++            switch$2 = 1; break;
++         }
++         if(! switch$2) return 66;
+         }
+         return _q_;
+        }
+        function _c_(_m_, _l_){
+-        if(65 === _m_)
+-         var _n_ = _l_;
+-        else{
+-         if(68 === _m_ && 68 === _l_) return 68;
+-         if(65 !== _l_){
+-          if(66 !== _l_ && 66 !== _m_){67 === _m_; return 67;}
+-          return 66;
++        var switch$0 = 0;
++        if(typeof _m_ === "number")
++         if(65 === _m_){
++          var _n_ = _l_;
++          switch$0 = 1;
++         }
++         else if(68 === _m_ && typeof _l_ === "number" && 68 === _l_) return 68;
++        if(! switch$0){
++         var switch$1 = 0;
++         if(typeof _l_ === "number")
++          if(65 === _l_){
++           var _n_ = _m_;
++           switch$1 = 2;
++          }
++          else if(66 === _l_) switch$1 = 1;
++         var switch$2 = 0;
++         switch(switch$1){
++           case 0:
++            var switch$3 = 0;
++            if(typeof _m_ === "number")
++             if(66 === _m_) switch$3 = 1; else 67 === _m_;
++            if(! switch$3) return 67;
++            break;
++           case 2:
++            switch$2 = 1; break;
+          }
+-         var _n_ = _m_;
++         if(! switch$2) return 66;
+         }
+         return _n_;
+        }
+@@ -124,8 +160,9 @@ let () =
+       }
+       (globalThis));
+     //end |}];
+-  Util.compile_and_run ~debug:false prog;
+-  [%expect {|
++  Util.compile_and_run ~debug:false ~flags:[ "--disable"; "inline" ] prog;
++  [%expect
++    {|
+     [a] is: `C
+     [b] is: `A
+     [correct a b] is: `C
+
+From 0aa66c510f5409a22d7ddf955c1c824dcb74f069 Mon Sep 17 00:00:00 2001
+From: Hugo Heuzard <hugo.heuzard@gmail.com>
+Date: Tue, 4 Jul 2023 01:00:41 +0200
+Subject: [PATCH 3/5] make test pass with ocaml414
+
+---
+ compiler/tests-compiler/gh1481.ml | 118 ------------------------------
+ 1 file changed, 118 deletions(-)
+
+diff --git a/compiler/tests-compiler/gh1481.ml b/compiler/tests-compiler/gh1481.ml
+index 279a269665..6fe64ef504 100644
+--- a/compiler/tests-compiler/gh1481.ml
++++ b/compiler/tests-compiler/gh1481.ml
+@@ -42,124 +42,6 @@ let () =
+
+   |}
+   in
+-  let program = Util.compile_and_parse ~debug:false prog in
+-  Util.print_program program;
+-  [%expect
+-    {|
+-    (function(globalThis){
+-       "use strict";
+-       var
+-        runtime = globalThis.jsoo_runtime,
+-        caml_string_of_jsbytes = runtime.caml_string_of_jsbytes;
+-       function caml_call2(f, a0, a1){
+-        return (f.l >= 0 ? f.l : f.l = f.length) == 2
+-                ? f(a0, a1)
+-                : runtime.caml_call_gen(f, [a0, a1]);
+-       }
+-       var
+-        global_data = runtime.caml_get_global_data(),
+-        Stdlib_Printf = global_data.Stdlib__Printf,
+-        cst_D = caml_string_of_jsbytes("`D"),
+-        cst_C = caml_string_of_jsbytes("`C"),
+-        cst_B = caml_string_of_jsbytes("`B"),
+-        cst_A = caml_string_of_jsbytes("`A"),
+-        _e_ =
+-          [0,
+-           [11, caml_string_of_jsbytes("[a] is: "), [2, 0, [12, 10, 0]]],
+-           caml_string_of_jsbytes("[a] is: %s\n")],
+-        _g_ =
+-          [0,
+-           [11, caml_string_of_jsbytes("[b] is: "), [2, 0, [12, 10, 0]]],
+-           caml_string_of_jsbytes("[b] is: %s\n")],
+-        _i_ =
+-          [0,
+-           [11, caml_string_of_jsbytes("[correct a b] is: "), [2, 0, [12, 10, 0]]],
+-           caml_string_of_jsbytes("[correct a b] is: %s\n")],
+-        _k_ =
+-          [0,
+-           [11,
+-            caml_string_of_jsbytes("[incorrect a b] is: "),
+-            [2, 0, [12, 10, 0]]],
+-           caml_string_of_jsbytes("[incorrect a b] is: %s\n")];
+-       function _a_(_r_){
+-        return 67 <= _r_ ? 68 <= _r_ ? cst_D : cst_C : 66 <= _r_ ? cst_B : cst_A;
+-       }
+-       function _b_(_p_, _o_){
+-        var switch$0 = 0;
+-        if(typeof _p_ === "number")
+-         if(65 === _p_){
+-          var _q_ = _o_;
+-          switch$0 = 1;
+-         }
+-         else if(68 === _p_ && typeof _o_ === "number" && 68 === _o_) return 68;
+-        if(! switch$0){
+-         var switch$1 = 0;
+-         if(typeof _o_ === "number")
+-          if(65 === _o_){
+-           var _q_ = _p_;
+-           switch$1 = 2;
+-          }
+-          else if(66 === _o_) switch$1 = 1;
+-         var switch$2 = 0;
+-         switch(switch$1){
+-           case 0:
+-            var switch$3 = 0;
+-            if(typeof _p_ === "number")
+-             if(66 === _p_) switch$3 = 1; else 67 === _p_;
+-            if(! switch$3) return 67;
+-            break;
+-           case 2:
+-            switch$2 = 1; break;
+-         }
+-         if(! switch$2) return 66;
+-        }
+-        return _q_;
+-       }
+-       function _c_(_m_, _l_){
+-        var switch$0 = 0;
+-        if(typeof _m_ === "number")
+-         if(65 === _m_){
+-          var _n_ = _l_;
+-          switch$0 = 1;
+-         }
+-         else if(68 === _m_ && typeof _l_ === "number" && 68 === _l_) return 68;
+-        if(! switch$0){
+-         var switch$1 = 0;
+-         if(typeof _l_ === "number")
+-          if(65 === _l_){
+-           var _n_ = _m_;
+-           switch$1 = 2;
+-          }
+-          else if(66 === _l_) switch$1 = 1;
+-         var switch$2 = 0;
+-         switch(switch$1){
+-           case 0:
+-            var switch$3 = 0;
+-            if(typeof _m_ === "number")
+-             if(66 === _m_) switch$3 = 1; else 67 === _m_;
+-            if(! switch$3) return 67;
+-            break;
+-           case 2:
+-            switch$2 = 1; break;
+-         }
+-         if(! switch$2) return 66;
+-        }
+-        return _n_;
+-       }
+-       var _d_ = _a_(67);
+-       caml_call2(Stdlib_Printf[2], _e_, _d_);
+-       var _f_ = _a_(65);
+-       caml_call2(Stdlib_Printf[2], _g_, _f_);
+-       var _h_ = _a_(_b_(67, 65));
+-       caml_call2(Stdlib_Printf[2], _i_, _h_);
+-       var _j_ = _a_(_c_(67, 65));
+-       caml_call2(Stdlib_Printf[2], _k_, _j_);
+-       var Test = [0, _a_, _b_, _c_];
+-       runtime.caml_register_global(9, Test, "Test");
+-       return;
+-      }
+-      (globalThis));
+-    //end |}];
+   Util.compile_and_run ~debug:false ~flags:[ "--disable"; "inline" ] prog;
+   [%expect
+     {|
+
+From 35072aa464739cd3dd49d8d60b4c4051e47e3d91 Mon Sep 17 00:00:00 2001
+From: Hugo Heuzard <hugo.heuzard@gmail.com>
+Date: Tue, 4 Jul 2023 01:01:35 +0200
+Subject: [PATCH 4/5] typo
+
+---
+ compiler/lib/generate.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler/lib/generate.ml b/compiler/lib/generate.ml
+index 1033262d09..367e2041f2 100644
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -1731,7 +1731,7 @@ and colapse_frontier name st (new_frontier' : Addr.Set.t) interm =
+   if debug ()
+   then
+     Format.eprintf
+-      "Resove %s to %s;@,"
++      "Resolve %s to %s;@,"
+       (string_of_set new_frontier')
+       (string_of_set new_frontier);
+   if Addr.Set.cardinal new_frontier <= 1
+
+From 22c6931a39f802af2a905b4ccb2ac049694ab43a Mon Sep 17 00:00:00 2001
+From: Hugo Heuzard <hugo.heuzard@gmail.com>
+Date: Tue, 4 Jul 2023 01:10:02 +0200
+Subject: [PATCH 5/5] Changes
+
+---
+ CHANGES.md | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CHANGES.md b/CHANGES.md
+index c48f55e853..a26aefb02e 100644
+--- a/CHANGES.md
++++ b/CHANGES.md
+@@ -4,6 +4,8 @@
+ * Runtime: fix hashing of NaN (#1475)
+ * Runtime: float rounding should resolve tie away from zero (#1475)
+ * Runtime: fix Gc.stat, Gc.quick_stat, Gc.get (#1475)
++* Compiler: fix some miscompilation, probably introduced in jsoo 5.0.0,
++  revealed by OCaml 5.0 ?
+
+ # 5.3.0 (2023-??-??) - ??
+ ## Features/Changes

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-gh1904.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-gh1904.patch
@@ -1,0 +1,74 @@
+--- a/compiler/lib-wasm/gc_target.ml
++++ b/compiler/lib-wasm/gc_target.ml
+@@ -687,6 +687,10 @@
+
+   let tag e = wasm_array_get e (Arith.const 0l)
+
++  let check_is_float_array e =
++    let* float_array = Type.float_array_type in
++    Value.ref_test (Value.ref float_array) e
++
+   let array_length e =
+     let* block = Type.block_type in
+     let* e = wasm_cast block e in
+--- a/compiler/lib-wasm/generate.ml
++++ b/compiler/lib-wasm/generate.ml
+@@ -343,10 +343,17 @@
+                   x
+             | Extern "caml_check_bound_float", [ x; y ] ->
+                 seq
+-                  (let* cond =
+-                     Arith.uge (Value.int_val y) (Memory.float_array_length x)
++                  (let a = Code.Var.fresh () in
++                   let* () = store a x in
++                   let label = label_index context bound_error_pc in
++                   (* If this is not a float array, it must be the
++                      empty array, and the bound check should fail. *)
++                   let* cond = Arith.eqz (Memory.check_is_float_array (load a)) in
++                   let* () = instr (W.Br_if (label, cond)) in
++                   let* cond =
++                     Arith.uge (Value.int_val y) (Memory.float_array_length (load a))
+                    in
+-                   instr (W.Br_if (label_index context bound_error_pc, cond)))
++                   instr (W.Br_if (label, cond)))
+                   x
+             | Extern "caml_add_float", [ f; g ] -> float_bin_op Add f g
+             | Extern "caml_sub_float", [ f; g ] -> float_bin_op Sub f g
+--- a/compiler/lib-wasm/target_sig.ml
++++ b/compiler/lib-wasm/target_sig.ml
+@@ -61,6 +61,8 @@
+
+     val float_array_set : expression -> expression -> expression -> unit Code_generation.t
+
++    val check_is_float_array : expression -> expression
++
+     val gen_array_get : expression -> expression -> expression
+
+     val gen_array_set : expression -> expression -> expression -> unit Code_generation.t
+--- a/compiler/tests-wasm_of_ocaml/dune
++++ b/compiler/tests-wasm_of_ocaml/dune
+@@ -1,5 +1,5 @@
+ (tests
+- (names gh38 gh46 gh107 gh112)
++ (names gh38 gh46 gh107 gh112 gh1904)
+  (modes js wasm)
+  (js_of_ocaml
+   (flags :standard --disable optcall --no-inline))
+--- /dev/null
++++ b/compiler/tests-wasm_of_ocaml/gh1904.ml
+@@ -0,0 +1,15 @@
++let empty = [||]
++
++let get (x : float array) = x.(0)
++
++let set (x : float array) e = x.(0) <- e
++
++let catch_bound_error f x =
++  try
++    ignore (f x);
++    assert false
++  with Invalid_argument _ -> ()
++
++let () =
++  catch_bound_error get empty;
++  catch_bound_error (fun () -> set empty 0.) ()

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-iarray-primitives.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-iarray-primitives.patch
@@ -1,0 +1,32 @@
+--- a/runtime/js/array.js
++++ b/runtime/js/array.js
+@@ -131,3 +131,13 @@
+   for (var i = 1; i < len; i++) b[i] = 0;
+   return b
+ }
++
++// Provides: caml_iarray_of_array const
++function caml_iarray_of_array(a) {
++  return a;
++}
++
++// Provides: caml_array_of_iarray const
++function caml_array_of_iarray(a) {
++  return a;
++}
+--- a/runtime/wasm/array.wat
++++ b/runtime/wasm/array.wat
+@@ -293,4 +293,13 @@
+                (struct.get $float 0 (ref.cast (ref $float) (local.get $v)))
+                (local.get $len))))
+       (ref.i31 (i32.const 0)))
++
++
++   (func (export "caml_iarray_of_array")
++      (param $a (ref eq)) (result (ref eq))
++      (local.get $a))
++
++   (func (export "caml_array_of_iarray")
++      (param $a (ref eq)) (result (ref eq))
++      (local.get $a))
+ )

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-ident-is_global.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-ident-is_global.patch
@@ -1,0 +1,10 @@
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -103,6 +103,6 @@
+       let name = Ident.name id in
+       if Ident.is_predef id
+       then Some (Glob_predef name)
+-      else if Ident.global id
++      else if Ident.is_global id
+       then Some (Glob_compunit name)
+       else None

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-important-config-changes.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-important-config-changes.patch
@@ -1,0 +1,10 @@
+--- a/compiler/lib/config.ml
++++ b/compiler/lib/config.ml
+@@ -90,6 +90,6 @@
+ 
+   let safe_string = o ~name:"safestring" ~default:true
+ 
+-  let use_js_string = o ~name:"use-js-string" ~default:true
++  let use_js_string = o ~name:"use-js-string" ~default:false
+ 
+   let check_magic = o ~name:"check-magic-number" ~default:true

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-index-by-unboxed-int.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-index-by-unboxed-int.patch
@@ -1,0 +1,302 @@
+--- a/compiler/lib/flow.ml
++++ b/compiler/lib/flow.ml
+@@ -324,21 +324,29 @@
+ let the_const_of info x =
+   match x with
+   | Pv x ->
+-      get_approx
+-        info
+-        (fun x ->
+-          match info.info_defs.(Var.idx x) with
+-          | Expr (Constant ((Float _ | Int _ | NativeString _) as c)) -> Some c
+-          | Expr (Constant (String _ as c)) when Config.Flag.safe_string () -> Some c
+-          | Expr (Constant c) ->
+-              if Var.ISet.mem info.info_possibly_mutable x then None else Some c
+-          | _ -> None)
+-        None
+-        (fun u v ->
+-          match u, v with
+-          | Some i, Some j when constant_identical ~target i j -> u
+-          | _ -> None)
+-        x
++
++      (* If this variable was minted after we constructed the info table, conservatively
++         assume we know nothing. Transformations of array-access primitives in
++         [specialize_js.ml] mint variables in this way. *)
++      if Var.idx x >= Array.length info.Info.info_defs
++      then None
++      else (
++        get_approx
++          info
++          (fun x ->
++            match info.info_defs.(Var.idx x) with
++            | Expr (Constant ((Float _ | Int _ | NativeString _) as c)) -> Some c
++            | Expr (Constant (String _ as c)) when Config.Flag.safe_string () -> Some c
++            | Expr (Constant c) ->
++                if Var.ISet.mem info.info_possibly_mutable x then None else Some c
++            | _ -> None)
++          None
++          (fun u v ->
++            match u, v with
++            | Some i, Some j when constant_identical ~target i j -> u
++            | _ -> None)
++          x
++      )
+   | Pc c -> Some c
+
+ let the_int info x =
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -1099,6 +1099,7 @@
+       J.call (J.dot (s_var "Math") prim) [ cx; cy ] loc)
+
+ let _ =
++  register_un_prim "%identity" `Pure (fun cx _ -> cx);
+   register_un_prim_ctx "%caml_format_int_special" `Pure (fun ctx cx loc ->
+       let s = J.EBin (J.Plus, str_js_utf8 "", cx) in
+       ocaml_string ~ctx ~loc s);
+@@ -2101,6 +2102,20 @@
+   res
+
+ let init () =
++  (* There are many sets of primitives that have the same behavior in JSOO. The compiler
++     promises to export them as different primitives because there are other systems where
++     their behavior is different. For example, in javascript:
++     - [int]
++     - [int32]
++     - [int32#]
++     - [nativeint]
++     - [nativeint#]
++     have the same representation, and can share the definitions of many primitives.
++
++     [int64] (and [int64#]) have a different representation from these, and so most
++     primitives pertaining to [int64]s are implemented separately as runtime stubs, not as
++     aliases to [int] primitives.
++  *)
+   List.iter
+     ~f:(fun (nm, nm') -> Primitive.alias nm nm')
+     [ "%int_mul", "caml_mul"
+@@ -2120,6 +2135,7 @@
+     ; "caml_int32_shift_right_unsigned", "%int_lsr"
+     ; "caml_int32_of_int", "%identity"
+     ; "caml_int32_to_int", "%identity"
++    ; "caml_checked_int32_to_int", "%identity"
+     ; "caml_int32_of_float", "caml_int_of_float"
+     ; "caml_int32_to_float", "%identity"
+     ; "caml_int32_format", "caml_format_int"
+@@ -2139,6 +2155,7 @@
+     ; "caml_nativeint_shift_right_unsigned", "%int_lsr"
+     ; "caml_nativeint_of_int", "%identity"
+     ; "caml_nativeint_to_int", "%identity"
++    ; "caml_checked_nativeint_to_int", "%identity"
+     ; "caml_nativeint_of_float", "caml_int_of_float"
+     ; "caml_nativeint_to_float", "%identity"
+     ; "caml_nativeint_of_int32", "%identity"
+@@ -2160,9 +2177,13 @@
+     ; "caml_array_set_addr", "caml_array_set"
+     ; "caml_array_unsafe_get_float", "caml_array_unsafe_get"
+     ; "caml_floatarray_unsafe_get", "caml_array_unsafe_get"
++    ; "caml_array_unsafe_get_indexed_by_int32", "caml_array_unsafe_get"
++    ; "caml_array_unsafe_get_indexed_by_nativeint", "caml_array_unsafe_get"
+     ; "caml_array_unsafe_set_float", "caml_array_unsafe_set"
+     ; "caml_array_unsafe_set_addr", "caml_array_unsafe_set"
+     ; "caml_floatarray_unsafe_set", "caml_array_unsafe_set"
++    ; "caml_array_unsafe_set_indexed_by_int32", "caml_array_unsafe_set"
++    ; "caml_array_unsafe_set_indexed_by_nativeint", "caml_array_unsafe_set"
+     ; "caml_check_bound_gen", "caml_check_bound"
+     ; "caml_check_bound_float", "caml_check_bound"
+     ; "caml_alloc_dummy_float", "caml_alloc_dummy"
+--- a/compiler/lib/specialize_js.ml
++++ b/compiler/lib/specialize_js.ml
+@@ -164,6 +164,32 @@
+             ( x
+             , Prim
+                 ( Extern
++                    (( "caml_array_get_indexed_by_int32"
++                     | "caml_array_get_indexed_by_int64"
++                     | "caml_array_get_indexed_by_nativeint")
++                     as prim)
++                , [ y; z ] ) ) ->
++          let conv =
++            match prim with
++            | "caml_array_get_indexed_by_int32" -> "caml_checked_int32_to_int"
++            | "caml_array_get_indexed_by_int64" -> "caml_checked_int64_to_int"
++            | "caml_array_get_indexed_by_nativeint" -> "caml_checked_nativeint_to_int"
++            | _ -> assert false
++          in
++          let z' = Code.Var.fresh () in
++          let r =
++            (Let (z', Prim (Extern conv, [ z ])))
++            (* The recursive call to [aux] will optimize [caml_array_get] into
++               a nominally "unsafe" (but guarded) access.
++            *)
++            :: (Let (x, Prim (Extern "caml_array_get", [ y; Pv z' ])))
++            :: r
++          in
++          aux info checks r acc
++        | Let
++            ( x
++            , Prim
++                ( Extern
+                     (( "caml_array_get"
+                      | "caml_array_get_float"
+                      | "caml_floatarray_get"
+@@ -207,6 +233,32 @@
+             ( x
+             , Prim
+                 ( Extern
++                    (( "caml_array_set_indexed_by_int32"
++                     | "caml_array_set_indexed_by_int64"
++                     | "caml_array_set_indexed_by_nativeint")
++                     as prim)
++                , [ y; z; w ] ) ) ->
++          let conv =
++            match prim with
++            | "caml_array_set_indexed_by_int32" -> "caml_checked_int32_to_int"
++            | "caml_array_set_indexed_by_int64" -> "caml_checked_int64_to_int"
++            | "caml_array_set_indexed_by_nativeint" -> "caml_checked_nativeint_to_int"
++            | _ -> assert false
++          in
++          let z' = Code.Var.fresh () in
++          let r =
++            (Let (z', Prim (Extern conv, [ z ])))
++            (* The recursive call to [aux] will optimize [caml_array_set] into
++               a nominally "unsafe" (but guarded) access.
++            *)
++            :: (Let (x, Prim (Extern "caml_array_set", [ y; Pv z'; w ])))
++            :: r
++          in
++          aux info checks r acc
++        | Let
++            ( x
++            , Prim
++                ( Extern
+                     (( "caml_array_set"
+                      | "caml_array_set_float"
+                      | "caml_floatarray_set"
+--- a/compiler/lib-wasm/generate.ml
++++ b/compiler/lib-wasm/generate.ml
+@@ -159,9 +159,41 @@
+             let l = List.map ~f:transl_prim_arg l in
+             match p, l with
+             | Extern "caml_array_unsafe_get", [ x; y ] -> Memory.gen_array_get x y
++            | Extern (( "caml_array_unsafe_get_indexed_by_int32"
++                      | "caml_array_unsafe_get_indexed_by_int64"
++                      | "caml_array_unsafe_get_indexed_by_nativeint"
++                      ) as prim), [ x; y ] ->
++                let conv =
++                  match prim with
++                  | "caml_array_unsafe_get_indexed_by_int32" -> Memory.unbox_int32
++                  | "caml_array_unsafe_get_indexed_by_int64" ->
++                    fun i ->
++                      let* i = Memory.unbox_int64 i in
++                      return (W.I32WrapI64 i)
++                  | "caml_array_unsafe_get_indexed_by_nativeint" -> Memory.unbox_nativeint
++                  | _ -> assert false
++                in
++                Memory.gen_array_get x (Value.val_int (conv y))
+             | Extern "caml_floatarray_unsafe_get", [ x; y ] -> Memory.float_array_get x y
+             | Extern "caml_array_unsafe_set", [ x; y; z ] ->
+                 seq (Memory.gen_array_set x y z) Value.unit
++            | Extern (( "caml_array_unsafe_set_indexed_by_int32"
++                      | "caml_array_unsafe_set_indexed_by_int64"
++                      | "caml_array_unsafe_set_indexed_by_nativeint"
++                      ) as prim), [ x; y; z ] ->
++                let conv =
++                  match prim with
++                  | "caml_array_unsafe_set_indexed_by_int32" -> Memory.unbox_int32
++                  | "caml_array_unsafe_set_indexed_by_int64" ->
++                    fun i ->
++                      let* i = Memory.unbox_int64 i in
++                      return (W.I32WrapI64 i)
++                  | "caml_array_unsafe_set_indexed_by_nativeint" -> Memory.unbox_nativeint
++                  | _ -> assert false
++                in
++                seq
++                  (Memory.gen_array_set x (Value.val_int (conv y)) z)
++                  Value.unit
+             | Extern "caml_array_unsafe_set_addr", [ x; y; z ] ->
+                 seq (Memory.array_set x y z) Value.unit
+             | Extern "caml_floatarray_unsafe_set", [ x; y; z ] ->
+@@ -1071,7 +1103,8 @@
+     [ "caml_make_array", "%identity"
+     ; "caml_ensure_stack_capacity", "%identity"
+     ; "caml_callback", "caml_trampoline"
+     ; "caml_make_array", "caml_array_of_uniform_array"
++    ; "caml_checked_nativeint_to_int", "caml_checked_int32_to_int"
+     ]
+   in
+
+--- a/runtime/js/int64.js
++++ b/runtime/js/int64.js
+@@ -270,6 +270,27 @@
+ //Provides: caml_int64_to_int32 const
+ function caml_int64_to_int32 (x) { return x.toInt() }
+
++//Provides: caml_checked_int64_to_int const
++//Requires: caml_int64_of_int32, caml_failwith
++function caml_checked_int64_to_int (x) {
++  if (x.compare(caml_int64_of_int32(0x7FFFFFFF)) == 1
++    || x.compare(caml_int64_of_int32(0x80000000)) == -1)
++    caml_failwith("error while converting from int64")
++  return x.toInt()
++}
++
++//Provides: caml_array_unsafe_get_indexed_by_int64 (mutable, const)
++//Requires: caml_int64_to_int32, caml_array_get
++function caml_array_unsafe_get_indexed_by_int64 (array, index) {
++  return caml_array_get(array, caml_int64_to_int32(index));
++}
++
++//Provides: caml_array_unsafe_set_indexed_by_int64 (mutable, const, mutable)
++//Requires: caml_int64_to_int32, caml_array_set
++function caml_array_unsafe_set_indexed_by_int64 (array, index, newval) {
++  return caml_array_set(array, caml_int64_to_int32(index), newval)
++}
++
+ //Provides: caml_int64_to_float const
+ function caml_int64_to_float (x) { return x.toFloat () }
+
+--- a/runtime/wasm/int32.wat
++++ b/runtime/wasm/int32.wat
+@@ -113,6 +113,20 @@
+          (call $parse_int
+             (local.get $v) (i32.const 32) (global.get $INT32_ERRMSG))))
+
++   (data $integer_conversion_error "error while converting from int32")
++
++   (func $caml_checked_int32_to_int (export "caml_checked_int32_to_int")
++      (param (ref eq)) (result (ref eq))
++      (local $i i32)
++      (local.set $i
++         (struct.get $int32 1 (ref.cast (ref $int32) (local.get 0))))
++      (if (i32.or (i32.gt_s (local.get $i) (i32.const  0x3FFFFFFF))
++                  (i32.lt_s (local.get $i) (i32.const -0x40000000)))
++          (then (call $caml_failwith
++                      (array.new_data $bytes $integer_conversion_error
++                                      (i32.const 0) (i32.const 33)))))
++      (ref.i31 (local.get $i)))
++
+    (export "caml_nativeint_compare" (func $caml_int32_compare))
+    (func $caml_int32_compare (export "caml_int32_compare")
+       (param (ref eq)) (param (ref eq)) (result (ref eq))
+--- a/runtime/wasm/int64.wat
++++ b/runtime/wasm/int64.wat
+@@ -328,4 +328,17 @@
+                               (local.get $uppercase)))))))))
+       (local.get $s))
+
++   (data $integer_conversion_error "error while converting from int64")
++
++   (func $caml_checked_int64_to_int (export "caml_checked_int64_to_int")
++      (param (ref eq)) (result (ref eq))
++      (local $i i64)
++      (local.set $i
++         (struct.get $int64 1 (ref.cast (ref $int64) (local.get 0))))
++      (if (i32.or (i64.gt_s (local.get $i) (i64.const  0x3FFFFFFF))
++                  (i64.lt_s (local.get $i) (i64.const -0x40000000)))
++          (then (call $caml_failwith
++                      (array.new_data $bytes $integer_conversion_error
++                                      (i32.const 0) (i32.const 33)))))
++      (ref.i31 (i32.wrap_i64 (local.get $i))))
+ )

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-int64-of-string-fixes.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-int64-of-string-fixes.patch
@@ -1,0 +1,49 @@
+--- a/runtime/js/int64.js
++++ b/runtime/js/int64.js
+@@ -27,6 +27,10 @@
+     this.hi = hi & 0xffff;
+     this.caml_custom = "_j";
+   }
++
++  static UNSIGNED_MAX = new MlInt64(0xffffff, 0xffffff, 0xffff);
++  static SIGNED_MAX = new MlInt64(0xffffff, 0xffffff, 0x7fff);
++  static SIGNED_MIN = new MlInt64(0x000000, 0x000000, 0x8000);
+
+   copy() {
+     return new MlInt64(this.lo, this.mi, this.hi);
+@@ -339,12 +343,10 @@
+     base = r[2],
+     signedness = r[3];
+   var base64 = caml_int64_of_int32(base);
+-  var threshold = new MlInt64(0xffffff, 0xfffffff, 0xffff).udivmod(
+-    base64,
+-  ).quotient;
++  var threshold = MlInt64.UNSIGNED_MAX.udivmod(base64).quotient;
+   var c = caml_string_unsafe_get(s, i);
+   var d = caml_parse_digit(c);
+-  if (d < 0 || d >= base) caml_failwith("int_of_string");
++  if (d < 0 || d >= base) caml_failwith("Int64.of_string");
+   var res = caml_int64_of_int32(d);
+   for (;;) {
+     i++;
+@@ -352,15 +354,15 @@
+     d = caml_parse_digit(c);
+     if (d < 0 || d >= base) break;
+     /* Detect overflow in multiplication base * res */
+-    if (caml_int64_ult(threshold, res)) caml_failwith("int_of_string");
++    if (caml_int64_ult(threshold, res)) caml_failwith("Int64.of_string");
+     d = caml_int64_of_int32(d);
+     res = caml_int64_add(caml_int64_mul(base64, res), d);
+     /* Detect overflow in addition (base * res) + d */
+-    if (caml_int64_ult(res, d)) caml_failwith("int_of_string");
++    if (caml_int64_ult(res, d)) caml_failwith("Int64.of_string");
+   }
+-  if (i !== caml_ml_string_length(s)) caml_failwith("int_of_string");
+-  if (signedness && caml_int64_ult(new MlInt64(0, 0, 0x8000), res))
+-    caml_failwith("int_of_string");
++  if (i !== caml_ml_string_length(s)) caml_failwith("Int64.of_string");
++  if (signedness && caml_int64_ult(sign < 0 ? MlInt64.SIGNED_MIN : MlInt64.SIGNED_MAX, res))
++    caml_failwith("Int64.of_string");
+   if (sign < 0) res = caml_int64_neg(res);
+   return res;
+ }

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-int_u-array-primitives.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-int_u-array-primitives.patch
@@ -1,0 +1,15 @@
+--- a/compiler/lib/specialize_js.ml
++++ b/compiler/lib/specialize_js.ml
+@@ -24,6 +24,12 @@
+
+ let specialize_instr ~target info i =
+   match i, target with
++  | Let (x, Prim (Extern "caml_make_unboxed_int32_vect_bytecode", [y])), _ ->
++      Let (x, Prim (Extern "caml_make_vect", [y; Pc (Int32 0l)]))
++  | Let (x, Prim (Extern "caml_make_unboxed_int64_vect_bytecode", [y])), _ ->
++      Let (x, Prim (Extern "caml_make_vect", [y; Pc (Int64 0L)]))
++  | Let (x, Prim (Extern "caml_make_unboxed_nativeint_vect_bytecode", [y])), _ ->
++      Let (x, Prim (Extern "caml_make_vect", [y; Pc (NativeInt 0l)]))
+   | Let (x, Prim (Extern "caml_format_int", [ y; z ])), `JavaScript -> (
+       match the_string_of info y with
+       | Some "%d" -> (

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-internal-keyboard_code-changes.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-internal-keyboard_code-changes.patch
@@ -1,0 +1,184 @@
+diff --git a/lib/js_of_ocaml/dom_html.ml b/lib/js_of_ocaml/dom_html.ml
+--- a/lib/js_of_ocaml/dom_html.ml
++++ b/lib/js_of_ocaml/dom_html.ml
+@@ -3203,6 +3203,139 @@ module Keyboard_code = struct
+     | "Pause" -> Pause
+     | _ -> Unidentified
+ 
++  let try_key location v =
++    match Js.to_string v with
++    | "a" | "A" -> KeyA
++    | "b" | "B" -> KeyB
++    | "c" | "C" -> KeyC
++    | "d" | "D" -> KeyD
++    | "e" | "E" -> KeyE
++    | "f" | "F" -> KeyF
++    | "g" | "G" -> KeyG
++    | "h" | "H" -> KeyH
++    | "i" | "I" -> KeyI
++    | "j" | "J" -> KeyJ
++    | "k" | "K" -> KeyK
++    | "l" | "L" -> KeyL
++    | "m" | "M" -> KeyM
++    | "n" | "N" -> KeyN
++    | "o" | "O" -> KeyO
++    | "p" | "P" -> KeyP
++    | "q" | "Q" -> KeyQ
++    | "r" | "R" -> KeyR
++    | "s" | "S" -> KeyS
++    | "t" | "T" -> KeyT
++    | "u" | "U" -> KeyU
++    | "v" | "V" -> KeyV
++    | "w" | "W" -> KeyW
++    | "x" | "X" -> KeyX
++    | "y" | "Y" -> KeyY
++    | "z" | "Z" -> KeyZ
++    | "0" -> Digit0
++    | "1" -> Digit1
++    | "2" -> Digit2
++    | "3" -> Digit3
++    | "4" -> Digit4
++    | "5" -> Digit5
++    | "6" -> Digit6
++    | "7" -> Digit7
++    | "8" -> Digit8
++    | "9" -> Digit9
++    | "-" -> Minus
++    | "=" -> Equal
++    (* Whitespace *)
++    | "Tab" -> Tab
++    | "Enter" -> (
++        match location with
++        | `Numpad -> NumpadEnter
++        | _ -> Enter)
++    | " " -> Space
++    (* Editing *)
++    | "Escape" -> Escape
++    | "Backspace" -> Backspace
++    | "Insert" -> Insert
++    | "Delete" -> Delete
++    | "CapsLock" -> CapsLock
++    (* Misc Printable *)
++    | "[" -> BracketLeft
++    | "]" -> BracketRight
++    | ";" -> Semicolon
++    | "\"" -> Quote
++    | "`" -> Backquote
++    | "\\" -> Backslash
++    | "," -> Comma
++    | "." -> Period
++    | "/" -> Slash
++    (* Function keys *)
++    | "F1" -> F1
++    | "F2" -> F2
++    | "F3" -> F3
++    | "F4" -> F4
++    | "F5" -> F5
++    | "F6" -> F6
++    | "F7" -> F7
++    | "F8" -> F8
++    | "F9" -> F9
++    | "F10" -> F10
++    | "F11" -> F11
++    | "F12" -> F12
++    (* Numpad keys *)
++    | "NumLock" -> NumLock
++    (* Modifier keys *)
++    | "Control" -> (
++        match location with
++        | `Left -> ControlLeft
++        | `Right | _ -> ControlRight)
++    | "Meta" -> (
++        match location with
++        | `Left -> MetaLeft
++        | `Right | _ -> MetaRight)
++    | "Shift" -> (
++        match location with
++        | `Left -> ShiftLeft
++        | `Right | _ -> ShiftRight)
++    | "Alt" -> (
++        match location with
++        | `Left -> AltLeft
++        | `Right | _ -> AltRight)
++    (* Arrow keys *)
++    | "ArrowLeft" -> ArrowLeft
++    | "ArrowRight" -> ArrowRight
++    | "ArrowUp" -> ArrowUp
++    | "ArrowDown" -> ArrowDown
++    (* Navigation *)
++    | "PageUp" -> PageUp
++    | "PageDown" -> PageDown
++    | "Home" -> Home
++    | "End" -> End
++    (* Sound *)
++    | "AudioVolumeMute" -> VolumeMute
++    | "AudioVolumeDown" -> VolumeDown
++    | "AudioVolumeUp" -> VolumeUp
++    (* Media *)
++    | "MediaTrackPrevious" -> MediaTrackPrevious
++    | "MediaTrackNext" -> MediaTrackNext
++    | "MediaPlayPause" -> MediaPlayPause
++    | "MediaStop" -> MediaStop
++    (* Browser special *)
++    | "ContextMenu" -> ContextMenu
++    | "BrowserSearch" -> BrowserSearch
++    | "BrowserHome" -> BrowserHome
++    | "BrowserFavorites" -> BrowserFavorites
++    | "BrowserRefresh" -> BrowserRefresh
++    | "BrowserStop" -> BrowserStop
++    | "BrowserForward" -> BrowserForward
++    | "BrowserBack" -> BrowserBack
++    (* Misc *)
++    | "OSLeft" -> OSLeft
++    | "OSRight" -> OSRight
++    | "ScrollLock" -> ScrollLock
++    | "PrintScreen" -> PrintScreen
++    | "IntlBackslash" -> IntlBackslash
++    | "IntlYen" -> IntlYen
++    | "Pause" -> Pause
++    | _ -> Unidentified
++
+   let try_key_code_left = function
+     | 16 -> ShiftLeft
+     | 17 -> ControlLeft
+@@ -3341,19 +3474,33 @@ module Keyboard_code = struct
+ 
+   let get_key_code evt = evt##.keyCode
+ 
+-  let try_key_location evt =
+-    match evt##.location with
+-    | 1 -> run_next (get_key_code evt) try_key_code_left
+-    | 2 -> run_next (get_key_code evt) try_key_code_right
+-    | 3 -> run_next (get_key_code evt) try_key_code_numpad
+-    | _ -> make_unidentified
++  let try_key_location location evt =
++    match location with
++    | `Left -> run_next (get_key_code evt) try_key_code_left
++    | `Right -> run_next (get_key_code evt) try_key_code_right
++    | `Numpad -> run_next (get_key_code evt) try_key_code_numpad
++    | `Other -> fun x -> x
+ 
+   let ( |> ) x f = f x
+ 
++  (* On the event, we have access to both `key` and `code` which are strings representing
++     which key was pressed.  `key` is for the "intended" key; that is to say, it takes
++     into account keyboard locale and software defined keyboard remappings (like QWERTY ->
++     Dvorak).  `code` is for the physical key that was pressed.  We almost always want to
++     use `key` over `code`. *)
+   let of_event evt =
++    (* https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/location *)
++    let location =
++      match evt##.location with
++      | 1 -> `Left
++      | 2 -> `Right
++      | 3 -> `Numpad
++      | _ -> `Other
++    in
+     Unidentified
++    |> try_next evt##.key (try_key location)
+     |> try_next evt##.code try_code
+-    |> try_key_location evt
++    |> try_key_location location evt
+     |> run_next (get_key_code evt) try_key_code_normal
+ 
+   let of_key_code = try_key_code_normal

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-internal-ocaml-5-compatibility.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-internal-ocaml-5-compatibility.patch
@@ -1,0 +1,28 @@
+--- a/runtime/js/sys.js
++++ b/runtime/js/sys.js
+@@ -290,8 +290,13 @@
+ function caml_sys_isatty(_chan) {
+   return 0;
+ }
+
++//Provides: caml_sys_const_runtime5 const
++function caml_sys_const_runtime5(_unit) {
++    return 0;
++}
++
+ //Provides: caml_runtime_variant
+ //Requires: caml_string_of_jsbytes
+ function caml_runtime_variant(_unit) {
+   return caml_string_of_jsbytes("");
+--- a/runtime/wasm/sys.wat
++++ b/runtime/wasm/sys.wat
+@@ -146,5 +146,9 @@
+       (param (ref eq)) (result (ref eq))
+       (ref.i31 (i32.const 0)))
+
++   (func (export "caml_sys_const_runtime5")
++      (param (ref eq)) (result (ref eq))
++      (ref.i31 (i32.const 0)))
++
+    (func (export "caml_runtime_variant") (param (ref eq)) (result (ref eq))
+       (array.new_fixed $bytes 0))

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-internal-stdlib-changes.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-internal-stdlib-changes.patch
@@ -1,0 +1,109 @@
+diff --git a/compiler/tests-compiler/effects_continuations.ml b/compiler/tests-compiler/effects_continuations.ml
+More stdlib offsets in internal-obj-changes.patch.
+--- a/compiler/tests-compiler/effects_continuations.ml
++++ b/compiler/tests-compiler/effects_continuations.ml
+@@ -201,7 +200,7 @@ let%expect_test "test-compiler/lib-effec
+     }
+     //end
+     function loop3(param, cont){
+-     var _f_ = Stdlib_List[9];
++     var _f_ = Stdlib_List[10];
+      return caml_cps_call2
+              (_f_,
+               _e_,
+diff --git a/compiler/tests-compiler/gh1007.ml b/compiler/tests-compiler/gh1007.ml
+--- a/compiler/tests-compiler/gh1007.ml
++++ b/compiler/tests-compiler/gh1007.ml
+@@ -498,12 +498,12 @@ let ()  = M.run ()
+       var _e_ = i + 1 | 0;
+       if(4 !== i){var i = _e_; continue;}
+       var
+-       _c_ = caml_call1(Stdlib_List[9], delayed[1]),
++       _c_ = caml_call1(Stdlib_List[10], delayed[1]),
+        _d_ = function(f){return caml_call1(f, 0);};
+-      return caml_call2(Stdlib_List[17], _d_, _c_);
++      return caml_call2(Stdlib_List[18], _d_, _c_);
+      }
+     }
+     //end |}]
+
+ let%expect_test _ =
+   let prog =
+@@ -622,10 +623,10 @@ let ()  = M.run ()
+        var _g_ = i + 1 | 0;
+        if(4 !== i){var i = _g_; continue a;}
+        var
+-        _e_ = caml_call1(Stdlib_List[9], delayed[1]),
++        _e_ = caml_call1(Stdlib_List[10], delayed[1]),
+         _f_ = function(f){return caml_call1(f, 0);};
+-       return caml_call2(Stdlib_List[17], _f_, _e_);
++       return caml_call2(Stdlib_List[18], _f_, _e_);
+       }
+      }
+     }
+     //end |}]
+diff --git a/compiler/tests-compiler/loops.ml b/compiler/tests-compiler/loops.ml
+--- a/compiler/tests-compiler/loops.ml
++++ b/compiler/tests-compiler/loops.ml
+@@ -44,12 +44,12 @@ let%expect_test "rec-fun" =
+        continue;
+       }
+       var
+-       _a_ = caml_call1(Stdlib_List[9], acc$0),
+-       _b_ = caml_call1(Stdlib_List[9], _a_);
+-      return caml_call1(Stdlib_List[9], _b_);
++       _a_ = caml_call1(Stdlib_List[10], acc$0),
++       _b_ = caml_call1(Stdlib_List[10], _a_);
++      return caml_call1(Stdlib_List[10], _b_);
+      }
+     }
+     //end |}]
+
+ let%expect_test "rec-fun-2" =
+   let program =
+@@ -80,9 +81,9 @@ let rec fun_with_loop acc = function
+      for(;;){
+       if(! param$0){
+        var
+-        _c_ = caml_call1(Stdlib_List[9], acc$0),
+-        _d_ = caml_call1(Stdlib_List[9], _c_);
+-       return caml_call1(Stdlib_List[9], _d_);
++        _c_ = caml_call1(Stdlib_List[10], acc$0),
++        _d_ = caml_call1(Stdlib_List[10], _c_);
++       return caml_call1(Stdlib_List[10], _d_);
+       }
+       var x = param$0[1];
+       if(1 === x && ! param$0[2]){
+@@ -481,7 +482,7 @@ let add_substitute =
+         var
+          match$0 =
+            [0,
+-            caml_call3(Stdlib_String[15], s, start$0, stop$0 - start$0 | 0),
++            caml_call3(Stdlib_String[16], s, start$0, stop$0 - start$0 | 0),
+             stop$0];
+         switch$0 = 1;
+         break;
+@@ -515,7 +516,7 @@ let add_substitute =
+          match$0 =
+            [0,
+             caml_call3
+-             (Stdlib_String[15], s, new_start, (stop - start$0 | 0) - 1 | 0),
++             (Stdlib_String[16], s, new_start, (stop - start$0 | 0) - 1 | 0),
+             stop + 1 | 0];
+         break;
+        }
+diff --git a/compiler/tests-compiler/mutable_closure.ml b/compiler/tests-compiler/mutable_closure.ml
+--- a/compiler/tests-compiler/mutable_closure.ml
++++ b/compiler/tests-compiler/mutable_closure.ml
+@@ -162,10 +162,10 @@ let%expect_test _ =
+       var
+        _c_ = indirect[1],
+        _d_ = function(f){return caml_call1(f, 0);},
+-       indirect$0 = caml_call2(Stdlib_List[19], _d_, _c_),
++       indirect$0 = caml_call2(Stdlib_List[20], _d_, _c_),
+        direct$0 = direct[1];
+       if(runtime.caml_equal(indirect$0, direct$0)) return 0;
+       throw caml_maybe_attach_backtrace([0, Assert_failure, _b_], 1);
+      }
+     }
+     //end|}]

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-jane-street-5.2-compatibility.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-jane-street-5.2-compatibility.patch
@@ -1,0 +1,85 @@
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -124,7 +124,7 @@
+     let to_ident = function
+       | Glob_compunit x -> Ident.create_persistent x
+       | Glob_predef x -> Ident.create_predef x
+-    [@@ocaml.warning "-32"]
++    [@@if ocaml_version < (5, 2, 0)]
+   end
+ 
+   module GlobalMap = struct
+@@ -160,11 +160,13 @@
+     include GlobalMap
+ 
+     let to_local = function
+-      | Symtable.Global.Glob_compunit (Compunit x) -> Global.Glob_compunit x
++      | Symtable.Global.Glob_compunit x ->
++          Global.Glob_compunit (Compilation_unit.name_as_string x)
+       | Symtable.Global.Glob_predef (Predef_exn x) -> Global.Glob_predef x
+ 
+     let of_local = function
+-      | Global.Glob_compunit x -> Symtable.Global.Glob_compunit (Compunit x)
++      | Global.Glob_compunit x ->
++          Symtable.Global.Glob_compunit (Compilation_unit.of_string x)
+       | Global.Glob_predef x -> Symtable.Global.Glob_predef (Predef_exn x)
+ 
+     let filter (p : Global.t -> bool) (gmap : t) =
+@@ -191,10 +193,10 @@
+   let reloc_set_of_string name = Cmo_format.Reloc_setglobal (Ident.create_persistent name)
+   [@@if ocaml_version < (5, 2, 0)]
+ 
+-  let reloc_get_of_string name = Cmo_format.Reloc_getcompunit (Compunit name)
++  let reloc_get_of_string name = Cmo_format.Reloc_getcompunit (Compilation_unit.of_string name)
+   [@@if ocaml_version >= (5, 2, 0)]
+ 
+-  let reloc_set_of_string name = Cmo_format.Reloc_setcompunit (Compunit name)
++  let reloc_set_of_string name = Cmo_format.Reloc_setcompunit (Compilation_unit.of_string name)
+   [@@if ocaml_version >= (5, 2, 0)]
+ 
+   let reloc_ident name =
+@@ -259,14 +261,13 @@
+   let name (t : t) = t.cu_name |> Compilation_unit.name_as_string [@@if ocaml_version < (5, 2, 0)]
+ 
+   let name (t : t) =
+-    let (Compunit name) = t.cu_name in
+-    name
++    Compilation_unit.name_as_string t.cu_name
+   [@@if ocaml_version >= (5, 2, 0)]
+ 
+   let requires (t : t) = List.map ~f:Compilation_unit.name_as_string t.cu_required_globals
+   [@@if ocaml_version < (5, 2, 0)]
+ 
+-  let requires (t : t) = List.map t.cu_required_compunits ~f:(fun (Compunit u) -> u)
++  let requires (t : t) = List.map t.cu_required_compunits ~f:Compilation_unit.name_as_string
+   [@@if ocaml_version >= (5, 2, 0)]
+ 
+   let provides (t : t) =
+@@ -279,7 +280,7 @@
+   let provides (t : t) =
+     List.filter_map t.cu_reloc ~f:(fun ((reloc : Cmo_format.reloc_info), _) ->
+         match reloc with
+-        | Reloc_setcompunit (Compunit u) -> Some u
++        | Reloc_setcompunit u -> Some (Compilation_unit.name_as_string u)
+         | Reloc_getcompunit _ | Reloc_getpredef _ | Reloc_literal _ | Reloc_primitive _ ->
+             None)
+   [@@if ocaml_version >= (5, 2, 0)]
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -2985,12 +2985,12 @@
+             patch (slot_for_global (Ident.name id))
+         | ((Reloc_setglobal id) [@if ocaml_version < (5, 2, 0)]) ->
+             patch (slot_for_global (Ident.name id))
+-        | ((Reloc_getcompunit (Compunit id)) [@if ocaml_version >= (5, 2, 0)]) ->
+-            patch (slot_for_global id)
++        | ((Reloc_getcompunit id) [@if ocaml_version >= (5, 2, 0)]) ->
++            patch (slot_for_global (Compilation_unit.name_as_string id))
+         | ((Reloc_getpredef (Predef_exn id)) [@if ocaml_version >= (5, 2, 0)]) ->
+             patch (slot_for_global id)
+-        | ((Reloc_setcompunit (Compunit id)) [@if ocaml_version >= (5, 2, 0)]) ->
+-            patch (slot_for_global id)
++        | ((Reloc_setcompunit id) [@if ocaml_version >= (5, 2, 0)]) ->
++            patch (slot_for_global (Compilation_unit.name_as_string id))
+         | _ -> ())
+ 
+   let primitives t =

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-jane-street-const_null-support.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-jane-street-const_null-support.patch
@@ -1,0 +1,12 @@
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -45,6 +45,9 @@
+   | Const_mixed_block (tag, _, l) | Const_block (tag, l) ->
+       let l = Array.of_list (List.map l ~f:constant_of_const) in
+       Tuple (tag, l, Unknown)
++  | Const_null ->
++
++    failwith "[Const_null] not supported in JavaScript yet."
+ 
+ let rec find_loc_in_summary ident' = function
+   | Env.Env_empty -> None

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-js-object-in-json-recovery.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-js-object-in-json-recovery.patch
@@ -1,0 +1,13 @@
+--- a/lib/js_of_ocaml/json.ml
++++ b/lib/js_of_ocaml/json.ml
+@@ -98,6 +98,10 @@
+           let i : int64 = Obj.obj v in
+           write_int64 b i
+       | id -> failwith (Printf.sprintf "Json.output: unsupported custom value %s " id)
++    else if t = Obj.abstract_tag
++      then
++        (* Presumably a JavaScript value *)
++        Buffer.add_string b (Js.to_string (Unsafe.global##._JSON##stringify v))
+     else failwith (Printf.sprintf "Json.output: unsupported tag %d " t)
+
+ let to_json v =

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-js-string-concat-bug.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-js-string-concat-bug.patch
@@ -1,0 +1,17 @@
+--- a/runtime/js/mlBytes.js
++++ b/runtime/js/mlBytes.js
+@@ -692,12 +692,10 @@
+ }
+
+ //Provides: caml_string_concat
+-//Requires: caml_convert_string_to_bytes, MlBytes
++//Requires: caml_string_of_jsbytes, caml_jsbytes_of_string
+ //If: !js-string
+ function caml_string_concat(s1, s2) {
+-  s1.t & 6 && caml_convert_string_to_bytes(s1);
+-  s2.t & 6 && caml_convert_string_to_bytes(s2);
+-  return new MlBytes(s1.t, s1.c + s2.c, s1.l + s2.l);
++  return caml_string_of_jsbytes(caml_jsbytes_of_string(s1) + caml_jsbytes_of_string(s2));
+ }
+
+ //Provides: caml_string_unsafe_get const

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-json-call.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-json-call.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/js_of_ocaml/json.ml b/lib/js_of_ocaml/json.ml
+Small typo in the upstream that makes this not work in the wasm case. This should be
+submitted as a PR.
+--- a/lib/js_of_ocaml/json.ml
++++ b/lib/js_of_ocaml/json.ml
+@@ -96,7 +96,7 @@ let rec write b v =
+     else if t = Obj.abstract_tag
+     then
+       (* Presumably a JavaScript value *)
+-      Buffer.add_string b (Js.to_string (Unsafe.global##_JSON##stringify v))
++      Buffer.add_string b (Js.to_string (Unsafe.global##._JSON##stringify v))
+     else failwith (Printf.sprintf "Json.output: unsupported tag %d " t)
+
+ let to_json v =

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-jsoo_link_read_files_once.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-jsoo_link_read_files_once.patch
@@ -1,0 +1,151 @@
+--- a/compiler/lib/link_js.ml
++++ b/compiler/lib/link_js.ml
+@@ -37,57 +37,55 @@
+
+   val drop : t -> unit
+
+-  val close : t -> unit
++  val reset : t -> unit
+
+   val lnum : t -> int
+
+   val fname : t -> string
+ end = struct
+   type t =
+-    { ic : in_channel
+-    ; fname : string
+-    ; mutable next : string option
++    { fname : string
++    ; lines  : string list
++    ; mutable current : string list
+     ; mutable lnum : int
+     }
+
+-  let close t = close_in t.ic
++  let reset t =
++    t.current <- t.lines;
++    t.lnum <- 0;
++  ;;
+
+   let open_ fname =
+-    let ic = open_in_bin fname in
+-    { ic; lnum = 0; fname; next = None }
++    let lines =
++
++      In_channel.input_all (open_in_bin fname) |> String.split_on_char ~sep:'\n'
++    in
++    { lines; lnum = 0; fname; current = lines }
+
+   let next t =
+     let lnum = t.lnum in
+     let s =
+-      match t.next with
+-      | None -> input_line t.ic
+-      | Some s ->
+-          t.next <- None;
+-          s
++      match t.current with
++      | [] -> raise End_of_file
++      | x :: rem ->
++        t.current <- rem;
++        x
+     in
+     t.lnum <- lnum + 1;
+     s
+
+   let peek t =
+-    match t.next with
+-    | Some x -> Some x
+-    | None -> (
+-        try
+-          let s = input_line t.ic in
+-          t.next <- Some s;
+-          Some s
+-        with End_of_file -> None)
++    match t.current with
++    | x :: _ -> Some x
++    | [] ->  None
+
+   let drop t =
+-    match t.next with
+-    | Some _ ->
+-        t.next <- None;
+-        t.lnum <- t.lnum + 1
+-    | None -> (
+-        try
+-          let (_ : string) = input_line t.ic in
+-          t.lnum <- t.lnum + 1
+-        with End_of_file -> ())
++    match t.current with
++    | [] -> ()
++    | _ :: rem ->
++      t.current <- rem;
++      t.lnum <- t.lnum + 1;
++  ;;
+
+   let lnum t = t.lnum
+
+@@ -191,7 +189,7 @@
+ module Units : sig
+   val read : Line_reader.t -> Unit_info.t -> Unit_info.t
+
+-  val scan_file : string -> Build_info.t option * Unit_info.t list
++  val scan_file : string -> Build_info.t option * Unit_info.t list * Line_reader.t
+ end = struct
+   let rec read ic uinfo =
+     match Line_reader.peek ic with
+@@ -239,8 +237,8 @@
+     in
+     let build_info = find_build_info ic in
+     let units = scan_all ic [] in
+-    Line_reader.close ic;
+-    build_info, units
++    Line_reader.reset ic;
++    build_info, units, ic
+ end
+
+ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~(source_map : Source_map.Spec.t option) =
+@@ -258,7 +256,7 @@
+     List.fold_right
+       files
+       ~init:(StringSet.empty, StringSet.empty, StringSet.empty)
+-      ~f:(fun (_file, (build_info, units)) acc ->
++      ~f:(fun (_file, (build_info, units, _reader)) acc ->
+         let cmo_file =
+           match build_info with
+           | Some bi -> (
+@@ -297,7 +295,7 @@
+   let t = Timer.make () in
+   let sym = ref Ocaml_compiler.Symtable.GlobalMap.empty in
+   let sym_js = ref [] in
+-  List.iter files ~f:(fun (_, (_, units)) ->
++  List.iter files ~f:(fun (_, (_, units, _reader)) ->
+       List.iter units ~f:(fun (u : Unit_info.t) ->
+           StringSet.iter
+             (fun s ->
+@@ -310,7 +308,7 @@
+             u.Unit_info.provides));
+
+   let build_info_emitted = ref false in
+-  List.iter files ~f:(fun (file, (build_info_for_file, units)) ->
++  List.iter files ~f:(fun (file, (build_info_for_file, units, reader)) ->
+       let is_runtime =
+         match build_info_for_file with
+         | Some bi -> (
+@@ -320,7 +318,7 @@
+         | None -> None
+       in
+       let sm_for_file = ref None in
+-      let ic = Line_reader.open_ file in
++      let ic = reader in
+       let skip ic = Line_reader.drop ic in
+       let reloc = ref [] in
+       let copy ic oc =
+@@ -411,6 +409,6 @@
+       in
+       read ();
+-      Line_reader.close ic;
++      Line_reader.reset ic;
+       (match is_runtime with
+       | None -> ()
+       | Some bi ->

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-list_map_tail_mod_cons.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-list_map_tail_mod_cons.patch
@@ -1,0 +1,15 @@
+--- a/compiler/lib/stdlib.ml
++++ b/compiler/lib/stdlib.ml
+@@ -156,7 +156,11 @@
+         :: f5
+         :: (if ctr > max_non_tailcall then slow_map ~f tl else count_map ~f tl (ctr + 1))
+ 
+-  let map l ~f = count_map ~f l 0
++  let[@tail_mod_cons] rec map l ~f =
++    match l with
++    | [] -> []
++    | x :: tl -> f x :: (map [@tailcall]) tl ~f
++  ;;
+ 
+   let rec take' acc n l =
+     if n = 0

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-magic_number.ml.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-magic_number.ml.patch
@@ -1,0 +1,21 @@
+--- a/compiler/lib/magic_number.ml
++++ b/compiler/lib/magic_number.ml
+@@ -64,8 +64,8 @@
+
+ let equal a b = compare a b = 0
+
+-let v =
+-  let current = Ocaml_version.current in
++let v = 559
++  (* let current = Ocaml_version.current in
+   match current with
+   | 4 :: 08 :: _ -> 25
+   | 4 :: 09 :: _ -> 26
+@@ -83,6 +83,6 @@
+       then failwith "OCaml version unsupported. Upgrade to OCaml 4.08 or newer."
+       else (
+         assert (Ocaml_version.compare current [ 5; 4 ] >= 0);
+-        failwith "OCaml version unsupported. Upgrade js_of_ocaml.")
++        failwith "OCaml version unsupported. Upgrade js_of_ocaml.") *)
+
+ let current_exe = "Caml1999X", v

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-migrate-labeled-tuples-shims.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-migrate-labeled-tuples-shims.patch
@@ -1,0 +1,11 @@
+--- a/compiler/ppx/ppx_optcomp_light.ml
++++ b/compiler/ppx/ppx_optcomp_light.ml
+@@ -164,7 +164,7 @@
+                 Bool false
+             | { pexp_desc = Pexp_constant (Pconst_integer (d, None)); _ } ->
+                 Int (int_of_string d)
+-            | { pexp_desc = Pexp_tuple l; _ } -> Tuple (List.map l ~f:eval)
++            | { pexp_desc = Pexp_tuple l; _ } -> Tuple (List.map l ~f:(fun (_label, l) -> eval l))
+             | { pexp_desc = Pexp_apply (op, [ (Nolabel, a); (Nolabel, b) ]); pexp_loc; _ }
+               -> (
+                 let op = get_bin_op op in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-mixed-block-bytecode-op-regression-test.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-mixed-block-bytecode-op-regression-test.patch
@@ -1,0 +1,18 @@
+--- a/compiler/lib/instr.ml
++++ b/compiler/lib/instr.ml
+@@ -419,3 +419,7 @@
+   let ins = ops.(i) in
+   if Poly.(ins.kind = K_will_not_happen) then raise (Bad_instruction i);
+   ins
++
++let get_instr_name i =
++  if i < 0 || i >= Array.length ops then raise (Bad_instruction i);
++  ops.(i).name
+--- a/compiler/lib/instr.mli
++++ b/compiler/lib/instr.mli
+@@ -207,3 +207,5 @@
+ val gets32 : string -> int -> int32
+ 
+ val getu32 : string -> int -> int32
++
++val get_instr_name : int -> string

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-mixed-block-bytecode-op.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-mixed-block-bytecode-op.patch
@@ -1,0 +1,56 @@
+--- a/compiler/lib/instr.ml
++++ b/compiler/lib/instr.ml
+@@ -169,6 +169,7 @@
+   | RERAISE
+   | RAISE_NOTRACE
+   | GETSTRINGCHAR
++  | MAKE_FAUX_MIXEDBLOCK
+   | PERFORM
+   | RESUME
+   | RESUMETERM
+@@ -353,13 +354,14 @@
+      ; RERAISE, KStop 0, "RERAISE"
+      ; RAISE_NOTRACE, KStop 0, "RAISE_NOTRACE"
+      ; GETSTRINGCHAR, KNullary, "GETSTRINGCHAR"
+      ; PERFORM, if_v500 KNullaryCall, "PERFORM"
+      ; RESUME, if_v500 KNullaryCall, "RESUME"
+      ; RESUMETERM, if_v500 (KStop 1), "RESUMETERM"
+      ; REPERFORMTERM, if_v500 (KStop 1), "REPERFORMTERM"
++     ; MAKE_FAUX_MIXEDBLOCK, KBinary, "MAKE_FAUX_MIXEDBLOCK"
+      ; FIRST_UNIMPLEMENTED_OP, K_will_not_happen, "FIRST_UNIMPLEMENTED_OP"
+     |]
+   in
+   let ops =
+     Array.mapi ~f:(fun i (c, k, n) -> { code = c; kind = k; name = n; opcode = i }) instrs
+   in
+--- a/compiler/lib/instr.mli
++++ b/compiler/lib/instr.mli
+@@ -168,6 +168,7 @@
+   | RERAISE
+   | RAISE_NOTRACE
+   | GETSTRINGCHAR
++  | MAKE_FAUX_MIXEDBLOCK
+   | PERFORM
+   | RESUME
+   | RESUMETERM
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -1375,7 +1375,7 @@
+           (pc + 2)
+           state
+           (Let (x, Block (i, [||], Unknown, Maybe_mutable)) :: instrs)
+-    | MAKEBLOCK ->
++    | MAKE_FAUX_MIXEDBLOCK | MAKEBLOCK ->
+         let size = getu code (pc + 1) in
+         let tag = getu code (pc + 2) in
+         let state = State.push state in
+--- a/compiler/lib/ocaml_compiler.ml	Mon Jul 22 18:34:59 2024 -0400
++++ b/compiler/lib/ocaml_compiler.ml	Mon Jul 22 18:28:48 2024 -0400
+@@ -42,6 +42,6 @@
+       Float_array (Array.of_list l)
+   | ((Const_pointer i) [@if ocaml_version < (4, 12, 0)]) ->
+       Int (Targetint.of_int_warning_on_overflow i)
+-  | Const_block (tag, l) ->
++  | Const_mixed_block (tag, _, l) | Const_block (tag, l) ->
+       let l = Array.of_list (List.map l ~f:constant_of_const) in
+       Tuple (tag, l, Unknown)

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-n-ary-functions.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-n-ary-functions.patch
@@ -1,0 +1,103 @@
+--- a/ppx/ppx_js/lib_internal/ppx_js_internal.ml
++++ b/ppx/ppx_js/lib_internal/ppx_js_internal.ml
+@@ -250,7 +250,7 @@
+   in
+   let make_fun (label, pat) (label', typ) expr =
+     assert (label' = label);
+-    Exp.fun_ label None (Pat.constraint_ pat typ) expr
++    Ppxlib_jane.Ast_builder.Default.add_fun_param ~loc:!Ppxlib.Ast_helper.default_loc label None (Pat.constraint_ pat typ) expr
+   in
+   let invoker =
+     List.fold_right2
+@@ -309,10 +309,10 @@
+   in
+   Exp.apply
+     ~loc:apply_loc
+-    { invoker with pexp_attributes = [ merlin_hide ] }
++    { invoker with pexp_attributes = invoker.pexp_attributes @ [ merlin_hide ] }
+     ((app_arg obj :: args)
+     @ [ app_arg
+-          (Exp.fun_
++          (Ppxlib_jane.Ast_builder.Default.add_fun_param
+              ~loc:gloc
+              nolabel
+              None
+@@ -355,7 +355,7 @@
+     invoker
+     [ app_arg obj
+     ; app_arg
+-        (Exp.fun_
++        (Ppxlib_jane.Ast_builder.Default.add_fun_param
+            ~loc:gloc
+            nolabel
+            None
+@@ -379,9 +379,8 @@
+ let prop_set ~loc ~prop_loc obj prop value =
+   let gloc = { obj.pexp_loc with Location.loc_ghost = true } in
+   let obj =
+-    { (Exp.constraint_ ~loc:gloc obj (open_t gloc)) with
+-      pexp_attributes = [ merlin_hide ]
+-    }
++    let body = Exp.constraint_ ~loc:gloc obj (open_t gloc) in
++    { body with pexp_attributes = body.pexp_attributes @ [ merlin_hide ] }
+   in
+   let invoker =
+     invoker
+@@ -409,7 +408,7 @@
+     [ app_arg obj
+     ; app_arg value
+     ; app_arg
+-        (Exp.fun_
++        (Ppxlib_jane.Ast_builder.Default.add_fun_param
+            ~loc:{ loc with loc_ghost = true }
+            nolabel
+            None
+@@ -583,11 +582,14 @@
+     | Pcf_method (id, priv, Cfk_concrete (bang, body)) ->
+         let names = check_name id names in
+         let body, body_ty = drop_pexp_poly (mappper body) in
+         let rec create_meth_ty exp =
+           match exp.pexp_desc with
+-          | Pexp_fun (label, _, _, body) -> Arg.make ~label () :: create_meth_ty body
+-          | Pexp_function _ -> [ Arg.make () ]
++          | Pexp_function (params, _, _) ->
++            List.filter_map params ~f:(fun param ->
++              match param.pparam_desc with
++              | Pparam_val (label, _, _) -> Some (Arg.make ~label ())
++              | Pparam_newtype _ -> None)
+-          | Pexp_newtype (_, body) -> create_meth_ty body
++          | Pexp_newtype (_, _, body) -> create_meth_ty body
+           | _ -> []
+         in
+         let fun_ty = create_meth_ty body in
+@@ -641,7 +643,7 @@
+   let body = function
+     | Val (_, _, _, body) -> body
+     | Meth (_, _, _, body, _) ->
+-        Exp.fun_ ~loc:{ body.pexp_loc with loc_ghost = true } Nolabel None self_id body
++      Ppxlib_jane.Ast_builder.Default.add_fun_param ~loc:{ body.pexp_loc with loc_ghost = true } Nolabel None self_id body
+   in
+   let extra_types =
+     List.concat
+@@ -725,14 +727,17 @@
+     invoker
+     (List.map fields ~f:(fun f -> app_arg (body f))
+     @ [ app_arg
+-          { (List.fold_right
++          (let body =
++             List.fold_right
+                (self :: List.map fields ~f:(fun f -> (name f).txt))
+                ~init:fake_object
+                ~f:(fun name fun_ ->
+-                 Exp.fun_ ~loc:gloc nolabel None (Pat.var ~loc:gloc (mknoloc name)) fun_))
++                 Ppxlib_jane.Ast_builder.Default.add_fun_param ~loc:gloc nolabel None (Pat.var ~loc:gloc (mknoloc name)) fun_)
++          in
++          { body
+             with
+-            pexp_attributes = [ merlin_hide ]
+-          }
++            pexp_attributes = body.pexp_attributes @ [ merlin_hide ]
++          })
+       ])
+
+ let transform =

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-obj_dup-mlBytes.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-obj_dup-mlBytes.patch
@@ -1,0 +1,18 @@
+--- a/runtime/js/obj.js
++++ b/runtime/js/obj.js
+@@ -92,14 +92,7 @@
+       }
+
+       if (x instanceof MlBytes) {
+-        if (typeof x.c === 'string') {
+-          // we can re-use the content because strings are immutable
+-          return new MlBytes(x.t, x.c, x.l);
+-        } else {
+-          // it must be an array, as defined in ./mlBytes.js
+-          var content = Array.prototype.slice.call(x.c);
+-          return new MlBytes(x.t, content, x.l);
+-        }
++        return MlBytes.prototype.slice.call(x);
+       }
+
+       if (x instanceof Array) {

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-ocaml_version-ppx.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-ocaml_version-ppx.patch
@@ -1,0 +1,24 @@
+--- a/toplevel/lib/jsooTop.ml
++++ b/toplevel/lib/jsooTop.ml
+@@ -65,6 +65,7 @@
+     p := !p + len'';
+     len''
+
++[%%if ocaml_version < (4, 14, 0)]
+ let use ffp content =
+   let fname, oc =
+     Filename.open_temp_file ~mode:[ Open_binary ] "jsoo_toplevel" "fake_stdin"
+@@ -78,10 +79,11 @@
+   with e ->
+     Sys.remove fname;
+     raise e
+-[@@if ocaml_version < (4, 14, 0)]
++[%%endif]
+
++[%%if ocaml_version >= (4, 14, 0)]
+ let use ffp content = Toploop.use_silently ffp (String content)
+-[@@if ocaml_version >= (4, 14, 0)]
++[%%endif]
+
+ let execute printval ?pp_code ?highlight_location pp_answer s =
+   let lb = Lexing.from_function (refill_lexbuf s (ref 0) pp_code) in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-opt-level-setting.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-opt-level-setting.patch
@@ -1,0 +1,20 @@
+diff --git a/compiler/lib/wasm/wa_binaryen.ml b/compiler/lib/wasm/wa_binaryen.ml
+O1 is changed because binaryen `-O2` is too slow. We probably want to undo this change
+once separate compilation is supported.
+skip-pass=inlining-optimizing is added to `-O3` because it seems to meaningfully improve
+startup performance.
+--- a/compiler/lib/wasm/wa_binaryen.ml
++++ b/compiler/lib/wasm/wa_binaryen.ml
+@@ -91,9 +91,9 @@ let dead_code_elimination
+   filter_unused_primitives primitives usage_file
+
+ let optimization_options =
+-  [| [ "-O2"; "--skip-pass=inlining-optimizing"; "--traps-never-happen" ]
+-   ; [ "-O2"; "--traps-never-happen" ]
+-   ; [ "-O3"; "--traps-never-happen" ]
++  [| [ "--simplify-locals-notee-nostructure"; "--vacuum"; "--reorder-locals"] (* --opt=1 *)
++   ; [ "-O2"; "--skip-pass=inlining-optimizing"; "--traps-never-happen" ] (* --opt=2 *)
++   ; [ "-O3"; "--skip-pass=inlining-optimizing"; "--traps-never-happen" ] (* --opt=3 *)
+   |]
+
+ let optimize

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-ppx_js_as_lib.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-ppx_js_as_lib.patch
@@ -1,0 +1,105 @@
+--- /dev/null
++++ b/ppx/ppx_js/as-lib/ppx_js_as_lib.ml
+@@ -0,0 +1,21 @@
++(* Js_of_ocaml library
++ * http://www.ocsigen.org/js_of_ocaml/
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation, with linking exception;
++ * either version 2.1 of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *)
++
++include Ppx_js_internal
++
++let () = wrapper := Some "Js_of_ocaml"
+--- /dev/null
++++ b/ppx/ppx_js/as-lib/ppx_js_as_lib.mli
+@@ -0,0 +1,24 @@
++(* Js_of_ocaml library
++ * http://www.ocsigen.org/js_of_ocaml/
++ *
++ * This program is free software; you can redistribute it and/or modify 
++ * it under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation, with linking exception;
++ * either version 2.1 of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *)
++
++(**/**)
++
++val mapper : Ast_mapper.mapper
++(** You can use this mapper to register the extension when building a toplevel.
++    You can only use it the way it is; it is not possible to update any fields 
++    of this mapper. *)
+--- /dev/null
++++ b/ppx/ppx_js/lib/ppx_js.ml
+@@ -0,0 +1,19 @@
++(* Js_of_ocaml library
++ * http://www.ocsigen.org/js_of_ocaml/
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation, with linking exception;
++ * either version 2.1 of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *)
++
++include Ppx_js_as_lib
+--- /dev/null
++++ b/ppx/ppx_js/lib/ppx_js.mli
+@@ -0,0 +1,21 @@
++(* Js_of_ocaml library
++ * http://www.ocsigen.org/js_of_ocaml/
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation, with linking exception;
++ * either version 2.1 of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *)
++
++(**/**)
++
++val mapper : Ast_mapper.mapper
+--- a/ppx/ppx_js/lib/ppx_js_rewriter.ml
++++ b/ppx/ppx_js/lib/ppx_js_rewriter.ml
+@@ -16,4 +16,4 @@
+  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+  *)
+ 
+-include Ppx_js
++include Ppx_js_as_lib

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-raise-is-reraise.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-raise-is-reraise.patch
@@ -1,0 +1,288 @@
+--- a/compiler/tests-compiler/effects_continuations.ml
++++ b/compiler/tests-compiler/effects_continuations.ml
+@@ -101,7 +101,6 @@
+   print_fun_decl code (Some "loop3");
+   [%expect
+     {|
+-
+     function exceptions(s, cont){
+      try{var _t_ = runtime.caml_int_of_string(s), n = _t_;}
+      catch(_x_){
+@@ -114,7 +113,7 @@
+      }
+      try{
+       if(caml_string_equal(s, cst$0))
+-       throw caml_maybe_attach_backtrace(Stdlib[8], 1);
++       throw caml_maybe_attach_backtrace(Stdlib[8], 0);
+       var _s_ = 7, m = _s_;
+      }
+      catch(_w_){
+@@ -137,7 +136,7 @@
+                cst_toto,
+                function(_u_){caml_pop_trap(); return cont([0, [0, _u_, n, m]]);});
+      var _r_ = Stdlib[8], raise = caml_pop_trap();
+-     return raise(caml_maybe_attach_backtrace(_r_, 1));
++     return raise(caml_maybe_attach_backtrace(_r_, 0));
+     }
+     //end
+     function cond1(b, cont){
+@@ -209,4 +208,5 @@
+                return _f_(l);
+               });
+     }
+-    //end |}]
++    //end
++    |}]
+--- a/compiler/tests-compiler/effects_exceptions.ml
++++ b/compiler/tests-compiler/effects_exceptions.ml
+@@ -55,7 +55,6 @@
+   print_fun_decl code (Some "exceptions");
+   [%expect
+     {|
+-
+     function exceptions(s, cont){
+      try{var _k_ = runtime.caml_int_of_string(s), n = _k_;}
+      catch(_o_){
+@@ -68,7 +67,7 @@
+      }
+      try{
+       if(caml_string_equal(s, cst$0))
+-       throw caml_maybe_attach_backtrace(Stdlib[8], 1);
++       throw caml_maybe_attach_backtrace(Stdlib[8], 0);
+       var _j_ = 7, m = _j_;
+      }
+      catch(_n_){
+@@ -91,9 +90,10 @@
+                cst_toto,
+                function(_l_){caml_pop_trap(); return cont([0, [0, _l_, n, m]]);});
+      var _i_ = Stdlib[8], raise = caml_pop_trap();
+-     return raise(caml_maybe_attach_backtrace(_i_, 1));
++     return raise(caml_maybe_attach_backtrace(_i_, 0));
+     }
+-    //end |}];
++    //end
++    |}];
+   print_fun_decl code (Some "handler_is_loop");
+   [%expect
+     {|
+@@ -112,7 +112,7 @@
+                    var
+                     exn = match[2],
+                     raise = caml_pop_trap(),
+-                    exn$0 = caml_maybe_attach_backtrace(exn, 1);
++                    exn$0 = caml_maybe_attach_backtrace(exn, 0);
+                    return raise(exn$0);
+                   });
+         }
+@@ -121,7 +121,8 @@
+      return caml_cps_call2
+              (f, 0, function(_d_){caml_pop_trap(); return cont(_d_);});
+     }
+-    //end |}];
++    //end
++    |}];
+   print_fun_decl code (Some "handler_is_merge_node");
+   [%expect
+     {|
+--- a/compiler/tests-compiler/eliminate_exception_handler.ml
++++ b/compiler/tests-compiler/eliminate_exception_handler.ml
+@@ -52,6 +52,7 @@
+   [%expect
+     {|
+     function some_name(param){
+-     try{throw caml_maybe_attach_backtrace(Stdlib[8], 1);}catch(_a_){return 0;}
++     try{throw caml_maybe_attach_backtrace(Stdlib[8], 0);}catch(_a_){return 0;}
+     }
+-    //end |}]
++    //end
++    |}]
+--- a/compiler/tests-compiler/exceptions.ml
++++ b/compiler/tests-compiler/exceptions.ml
+@@ -34,25 +34,27 @@
+     {|
+     function some_name(param){
+      try{
+-      try{throw caml_maybe_attach_backtrace(Stdlib[8], 1);}
++      try{throw caml_maybe_attach_backtrace(Stdlib[8], 0);}
+       catch(x$0){var x = caml_wrap_exception(x$0), i$0 = x;}
+      }
+      catch(i$1){var i = caml_wrap_exception(i$1), i$0 = i;}
+-     throw caml_maybe_attach_backtrace(i$0, 1);
++     throw caml_maybe_attach_backtrace(i$0, 0);
+     }
+-    //end |}];
++    //end
++    |}];
+   print_fun_decl (program ~debug:false) None;
+   [%expect
+     {|
+     function _a_(_b_){
+      try{
+-      try{throw caml_maybe_attach_backtrace(Stdlib[8], 1);}
++      try{throw caml_maybe_attach_backtrace(Stdlib[8], 0);}
+       catch(_f_){var _d_ = caml_wrap_exception(_f_);}
+      }
+      catch(_e_){
+       var _c_ = caml_wrap_exception(_e_);
+-      throw caml_maybe_attach_backtrace(_c_, 1);
++      throw caml_maybe_attach_backtrace(_c_, 0);
+      }
+-     throw caml_maybe_attach_backtrace(_d_, 1);
++     throw caml_maybe_attach_backtrace(_d_, 0);
+     }
+-    //end |}]
++    //end
++    |}]
+--- a/compiler/tests-compiler/gh1354.ml
++++ b/compiler/tests-compiler/gh1354.ml
+@@ -63,7 +63,7 @@
+         _b_ = _a_,
+         _d_ =
+           [0, [4, 0, 0, 0, [12, 10, 0]], runtime.caml_string_of_jsbytes("%d\n")];
+-       try{0; _b_ = _a_ + 1 | 0; throw caml_maybe_attach_backtrace(Stdlib[3], 1);}
++       try{0; _b_ = _a_ + 1 | 0; throw caml_maybe_attach_backtrace(Stdlib[3], 0);}
+        catch(_e_){
+         var _c_ = caml_wrap_exception(_e_);
+         if(_c_ !== Stdlib[3]) throw caml_maybe_attach_backtrace(_c_, 0);
+@@ -75,7 +75,8 @@
+        }
+       }
+       (globalThis));
+-    //end |}];
++    //end
++    |}];
+   Util.compile_and_run ~debug:false prog;
+   [%expect {|
+     1 |}]
+@@ -144,11 +145,11 @@
+          0;
+          _g_ = _i_;
+          _c_ = _i_;
+-         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
++         throw caml_maybe_attach_backtrace(Stdlib[3], 0);
+         }
+         catch(_k_){
+          caml_call3(Stdlib_Printf[3], _h_, _g_ | 0, _b_);
+-         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
++         throw caml_maybe_attach_backtrace(Stdlib[3], 0);
+         }
+        }
+        catch(_j_){
+@@ -162,7 +163,8 @@
+        }
+       }
+       (globalThis));
+-    //end |}];
++    //end
++    |}];
+   Util.compile_and_run ~debug:false prog;
+   [%expect {|
+     2 0
+@@ -220,11 +222,11 @@
+          0;
+          _e_ = _g_;
+          _b_ = _g_;
+-         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
++         throw caml_maybe_attach_backtrace(Stdlib[3], 0);
+         }
+         catch(_i_){
+          caml_call2(Stdlib_Printf[3], _f_, _e_);
+-         throw caml_maybe_attach_backtrace(Stdlib[3], 1);
++         throw caml_maybe_attach_backtrace(Stdlib[3], 0);
+         }
+        }
+        catch(_h_){
+@@ -238,7 +240,8 @@
+        }
+       }
+       (globalThis));
+-    //end |}];
++    //end
++    |}];
+   Util.compile_and_run ~debug:false prog;
+   [%expect {|
+     1
+--- a/compiler/tests-compiler/global_deadcode.ml
++++ b/compiler/tests-compiler/global_deadcode.ml
+@@ -77,7 +77,7 @@
+     function find(x, param){
+      var param$0 = param;
+      for(;;){
+-      if(! param$0) throw caml_maybe_attach_backtrace(Not_found, 1);
++      if(! param$0) throw caml_maybe_attach_backtrace(Not_found, 0);
+       var
+        r = param$0[3],
+        v = param$0[2],
+@@ -89,7 +89,8 @@
+      }
+     }
+     return [0, 0, add, singleton, find];
+-    //end |}]
++    //end
++    |}]
+
+ let%expect_test "Omit unused fields" =
+   let program =
+--- a/compiler/tests-compiler/loops.ml
++++ b/compiler/tests-compiler/loops.ml
+@@ -170,7 +170,7 @@
+        for(;;){
+         if(10 <= caml_div(k, j)) break;
+         try{caml_div(k, j);}
+-        catch(_c_){throw caml_maybe_attach_backtrace(Stdlib[8], 1);}
++        catch(_c_){throw caml_maybe_attach_backtrace(Stdlib[8], 0);}
+         id[1]++;
+        }
+        var _b_ = j + 1 | 0;
+@@ -182,7 +182,8 @@
+       k = _a_;
+      }
+     }
+-    //end |}]
++    //end
++    |}]
+
+ let%expect_test "loop seq.ml" =
+   let program =
+@@ -449,7 +450,7 @@
+        }
+        else{
+         var start$0 = i$4 + 1 | 0;
+-        if(lim$1 <= start$0) throw caml_maybe_attach_backtrace(Stdlib[8], 1);
++        if(lim$1 <= start$0) throw caml_maybe_attach_backtrace(Stdlib[8], 0);
+         var opening = caml_string_get(s, start$0);
+         a:
+         {
+@@ -499,7 +500,7 @@
+          }
+          var lim = caml_ml_string_length(s), k = k$2, stop = new_start;
+          for(;;){
+-          if(lim <= stop) throw caml_maybe_attach_backtrace(Stdlib[8], 1);
++          if(lim <= stop) throw caml_maybe_attach_backtrace(Stdlib[8], 0);
+           if(caml_string_get(s, stop) === opening){
+            var i = stop + 1 | 0, k$0 = k + 1 | 0;
+            k = k$0;
+@@ -544,7 +545,8 @@
+       }
+      }
+     }
+-    //end |}]
++    //end
++    |}]
+
+ let%expect_test "Bytes.trim" =
+   let program =
+@@ -606,10 +608,11 @@
+         var b = r;
+         break a;
+        }
+-       throw caml_maybe_attach_backtrace([0, Invalid_argument, s], 1);
++       throw caml_maybe_attach_backtrace([0, Invalid_argument, s], 0);
+       }
+       var b = empty;
+      }
+      return caml_string_of_bytes(copy(b));
+     }
+-    //end |}]
++    //end
++    |}]

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-re-allow-int32-nativeint-in-js.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-re-allow-int32-nativeint-in-js.patch
@@ -1,0 +1,26 @@
+--- a/compiler/lib/eval.ml
++++ b/compiler/lib/eval.ml
+@@ -385,9 +385,9 @@
+
+                             (* Avoid duplicating the constant here as it would cause an
+                                allocation *)
+                             arg
+-                        | Some (Int32 _ | NativeInt _), `JavaScript -> assert false
++                        | Some (Int32 _ | NativeInt _), `JavaScript -> arg
+                         | Some ((Float _ | NativeString _) as c), `JavaScript -> Pc c
+                         | Some (String _ as c), `JavaScript
+                           when Config.Flag.use_js_string () -> Pc c
+
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -494,8 +494,8 @@
+           in
+           Mlvalue.Block.make ~tag ~args:l, instrs)
+   | Int i -> targetint i, instrs
+-  | Int32 _ | NativeInt _ ->
+-      assert false (* Should not be produced when compiling to Javascript *)
++  | Int32 i | NativeInt i ->
++    J.ENum (J.Num.of_targetint (Targetint.of_int32_exn i)), instrs
+
+ let constant ~ctx x level =
+   let expr, instr = constant_rec ~ctx x level [] in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-remove-float-externals.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-remove-float-externals.patch
@@ -1,0 +1,29 @@
+--- a/compiler/tests-jsoo/test_floats.ml
++++ b/compiler/tests-jsoo/test_floats.ml
+@@ -26,26 +26,6 @@
+   Printf.printf "%g\n" (1. /. z);
+   [%expect {|-inf|}]
+ 
+-module Float = struct
+-  include Float
+-
+-  external acosh : float -> float = "caml_acosh_float"
+-
+-  external asinh : float -> float = "caml_asinh_float"
+-
+-  external atanh : float -> float = "caml_atanh_float"
+-
+-  external erf : float -> float = "caml_erf_float"
+-
+-  external erfc : float -> float = "caml_erfc_float"
+-
+-  external cbrt : float -> float = "caml_cbrt_float"
+-
+-  external exp2 : float -> float = "caml_exp2_float"
+-
+-  external log2 : float -> float = "caml_log2_float"
+-end
+-
+ let print f =
+   match Float.classify_float f with
+   | FP_nan -> print_endline "nan"

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-set-target-mkcmis.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-set-target-mkcmis.patch
@@ -1,0 +1,10 @@
+--- a/toplevel/bin/jsoo_mkcmis.ml
++++ b/toplevel/bin/jsoo_mkcmis.ml
+@@ -58,6 +58,7 @@
+   | [] -> List.rev acc
+
+ let () =
++  Js_of_ocaml_compiler.Config.set_target `JavaScript;
+   let args = List.tl (Array.to_list Sys.argv) in
+   let args = scan_args [] args in
+   let runtime_files, args =

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-short_circuit_javascript_lines_while_linking.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-short_circuit_javascript_lines_while_linking.patch
@@ -1,0 +1,23 @@
+--- a/compiler/lib/link_js.ml
++++ b/compiler/lib/link_js.ml
+@@ -170,7 +170,12 @@
+   | Build_info of Build_info.t
+   | Source_map of Source_map.t
+ 
++let info_prefix = "//#"
++
+ let prefix_kind line =
++  match String.is_prefix ~prefix:info_prefix line with
++  | false -> `Other
++  | true -> (
+   match String.is_prefix ~prefix:sourceMappingURL line with
+   | false -> (
+       match Build_info.parse line with
+@@ -183,6 +188,7 @@
+       match String.is_prefix ~prefix:sourceMappingURL_base64 line with
+       | true -> `Json_base64 (String.length sourceMappingURL_base64)
+       | false -> `Url (String.length sourceMappingURL))
++   )
+ 
+ let action ~resolve_sourcemap_url ~drop_source_map file line =
+   match prefix_kind line, drop_source_map with

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-stop-parsing-crcs.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-stop-parsing-crcs.patch
@@ -1,0 +1,97 @@
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -3220,7 +3220,6 @@
+   let unit_info =
+     { Unit_info.provides = StringSet.of_list (List.map ~f:snd predefined_exceptions)
+     ; requires = StringSet.empty
+-    ; crcs = StringMap.empty
+     ; force_link = true
+     ; effects_without_cps = false
+     ; primitives = []
+--- a/compiler/lib/unit_info.ml
++++ b/compiler/lib/unit_info.ml
+@@ -23,7 +23,6 @@
+   { provides : StringSet.t
+   ; requires : StringSet.t
+   ; primitives : string list
+-  ; crcs : Digest.t option StringMap.t
+   ; force_link : bool
+   ; effects_without_cps : bool
+   }
+@@ -32,7 +31,6 @@
+   { provides = StringSet.empty
+   ; requires = StringSet.empty
+   ; primitives = []
+-  ; crcs = StringMap.empty
+   ; force_link = false
+   ; effects_without_cps = false
+   }
+@@ -41,7 +39,6 @@
+   { provides = StringSet.empty
+   ; requires = StringSet.empty
+   ; primitives = l
+-  ; crcs = StringMap.empty
+   ; force_link = true
+   ; effects_without_cps = false
+   }
+@@ -59,40 +56,18 @@
+            | _ -> false)
+   in
+   let force_link = Cmo_format.force_link cmo in
+-  let crcs =
+-    Array.fold_left (Cmo_format.imports cmo) ~init:StringMap.empty ~f:(fun acc import ->
+-        let s = Compilation_unit.Name.to_string (Import_info.name import) in
+-        let o = Import_info.crc import in
+-        StringMap.add s o acc)
+-  in
+-  { provides; requires; primitives = []; force_link; effects_without_cps; crcs }
++  { provides; requires; primitives = []; force_link; effects_without_cps }
+
+ let union t1 t2 =
+   let provides = StringSet.union t1.provides t2.provides in
+   let requires = StringSet.union t1.requires t2.requires in
+   let requires = StringSet.diff requires provides in
+   let primitives = t1.primitives @ t2.primitives in
+-  let crcs =
+-    StringMap.merge
+-      (fun _ v1 v2 ->
+-        match v1, v2 with
+-        | None, x -> x
+-        | x, None -> x
+-        | Some None, Some x -> Some x
+-        | Some x, Some None -> Some x
+-        | Some (Some x), Some (Some y) ->
+-            if String.equal x y
+-            then Some (Some x)
+-            else failwith (Printf.sprintf "Inconsistent assumption blah.."))
+-      t1.crcs
+-      t2.crcs
+-  in
+   { provides
+   ; requires
+   ; primitives
+   ; force_link = t1.force_link || t2.force_link
+   ; effects_without_cps = t1.effects_without_cps || t2.effects_without_cps
+-  ; crcs
+   }
+
+ let prefix = "//# unitInfo:"
+--- a/compiler/lib/unit_info.mli
++++ b/compiler/lib/unit_info.mli
+@@ -23,7 +23,6 @@
+   { provides : StringSet.t
+   ; requires : StringSet.t
+   ; primitives : string list
+-  ; crcs : Digest.t option StringMap.t
+   ; force_link : bool
+   ; effects_without_cps : bool
+   }
+--- a/compiler/lib-wasm/link.ml
++++ b/compiler/lib-wasm/link.ml
+@@ -92,6 +92,5 @@
+     ; force_link = t |> member "force_link" |> bool empty.force_link
+     ; effects_without_cps =
+         t |> member "effects_without_cps" |> bool empty.effects_without_cps
+-    ; crcs = StringMap.empty
+     }
+ end

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-symtable-5.2-api.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-symtable-5.2-api.patch
@@ -1,0 +1,20 @@
+--- a/compiler/lib/ocaml_compiler.ml
++++ b/compiler/lib/ocaml_compiler.ml
+@@ -207,7 +207,7 @@
+     let get i = Char.code (Bytes.get buf i) in
+     let n = get 0 + (get 1 lsl 8) + (get 2 lsl 16) + (get 3 lsl 24) in
+     n
++  (* [@@if ocaml_version < (5, 2, 0)]
+-  [@@if ocaml_version < (5, 2, 0)]
+
+   let reloc_ident name =
+     let buf = Bigarray.(Array1.create char c_layout 4) in
+@@ -220,6 +220,8 @@
+     let n = get 0 + (get 1 lsl 8) + (get 2 lsl 16) + (get 3 lsl 24) in
+     n
+   [@@if ocaml_version >= (5, 2, 0)]
++  *)
++
+
+   let current_state () : GlobalMap.t =
+     let x : Symtable.global_map = Symtable.current_state () in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-test-diffs-caused-by-build-differences.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-test-diffs-caused-by-build-differences.patch
@@ -1,0 +1,20 @@
+--- a/compiler/tests-jsoo/gh_1307.ml
++++ b/compiler/tests-jsoo/gh_1307.ml
+@@ -15,7 +15,7 @@
+   test "a";
+   [%expect {|
+     input: "a"
+-    Stdlib.Parsing.Parse_error
++    Stdlib__Parsing.Parse_error
+     failure |}];
+   test "aa";
+   [%expect {|
+@@ -25,7 +25,7 @@
+   test "aaa";
+   [%expect {|
+     input: "aaa"
+-    Stdlib.Parsing.Parse_error
++    Stdlib__Parsing.Parse_error
+     failure |}];
+   let (_ : bool) = Parsing.set_trace old in
+   ()

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-tmp-import-patch.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-tmp-import-patch.patch
@@ -1,0 +1,17 @@
+--- a/compiler/tests-jsoo/test_marshal_compressed.ml
++++ b/compiler/tests-jsoo/test_marshal_compressed.ml
+@@ -16,7 +16,7 @@
+  * along with this program; if not, write to the Free Software
+  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+  *)
+-
++(*
+ let%expect_test _ =
+   let data =
+     "\132\149\166\189\r\022\206\021\001\147F\137d(\181/\253\000Xm\000\0000\n\
+@@ -28,4 +28,4 @@
+     else String.make 10000 'c'
+   in
+   Printf.printf "%s ... (%d)\n" (String.sub s 0 20) (String.length s);
+-  [%expect {| cccccccccccccccccccc ... (10000) |}]
++  [%expect {| cccccccccccccccccccc ... (10000) |}] *)

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-top-effects.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-top-effects.patch
@@ -1,0 +1,16 @@
+diff --git a/runtime/js/jslib.js b/runtime/js/jslib.js
+index 6a711bbb1d..081361a841 100644
+--- a/runtime/js/jslib.js
++++ b/runtime/js/jslib.js
+@@ -134,8 +134,9 @@ function caml_jsoo_flags_use_js_string(unit) {
+ }
+ 
+ //Provides: caml_jsoo_flags_effects
++//Requires: caml_string_of_jsstring
+ function caml_jsoo_flags_effects(unit) {
+-  return CONFIG("effects");
++  return caml_string_of_jsstring(CONFIG("effects"));
+ }
+ 
+ //Provides: caml_wrap_exception const (mutable)
+

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-toplevel.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-toplevel.patch
@@ -1,0 +1,238 @@
+diff --git a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+index 140a53b..d857289 100644
+--- a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
++++ b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+@@ -4,7 +4,7 @@ module J = Jsoo_runtime.Js
+
+ type bytecode_sections =
+   { symb : Ocaml_compiler.Symtable.GlobalMap.t
+-  ; crcs : (string * Digest.t option) list
++  ; crcs : Import_info.t array
+   ; prim : string list
+   ; dlpt : string list
+   }
+diff --git a/compiler/lib/link_js.ml b/compiler/lib/link_js.ml
+index 68f0c32..3ec9ddc 100644
+--- a/compiler/lib/link_js.ml
++++ b/compiler/lib/link_js.ml
+@@ -426,7 +426,7 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~(sourc
+             List.fold_left units ~init:StringSet.empty ~f:(fun acc (u : Unit_info.t) ->
+                 StringSet.union acc (StringSet.of_list u.primitives))
+           in
+-          let code = Parse_bytecode.link_info ~symbols:!sym ~primitives ~crcs:[] in
++          let code = Parse_bytecode.link_info ~symbols:!sym ~primitives ~crcs:[||] in
+           let b = Buffer.create 100 in
+           let fmt = Pretty_print.to_buffer b in
+           Driver.configure fmt;
+diff --git a/compiler/lib/parse_bytecode.ml b/compiler/lib/parse_bytecode.ml
+index 79e0c8f..bf8751a 100644
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -35,6 +35,9 @@ let predefined_exceptions =
+
+ let new_closure_repr = Ocaml_version.compare Ocaml_version.current [ 4; 12 ] >= 0
+
++let crc_name v = Import_info.name v |> Compilation_unit.Name.to_string
++let crc_crc v = Import_info.crc v
++
+ (* Read and manipulate debug section *)
+ module Debug : sig
+   type t
+@@ -76,11 +79,11 @@ module Debug : sig
+     -> unit
+
+   val read :
+-    t -> crcs:(string * string option) list -> includes:string list -> in_channel -> unit
++    t -> crcs:Import_info.t list -> includes:string list -> in_channel -> unit
+
+   val read_event_list :
+        t
+-    -> crcs:(string * string option) list
++    -> crcs:Import_info.t list
+     -> includes:string list
+     -> orig:int
+     -> in_channel
+@@ -146,6 +149,7 @@ end = struct
+     | Some _ as x -> x
+     | None -> Fs.find_in_path paths (name ^ ".ml")
+
++
+   let read_event
+       ~paths
+       ~crcs
+@@ -216,7 +220,7 @@ end = struct
+     fun debug ~crcs ~includes ~orig ic ->
+       let crcs =
+         let t = Hashtbl.create 17 in
+-        List.iter crcs ~f:(fun (m, crc) -> Hashtbl.add t m crc);
++        List.iter crcs ~f:(fun i -> Hashtbl.add t (crc_name i) (crc_crc i));
+         t
+       in
+       let evl : debug_event list = input_value ic in
+@@ -2520,7 +2524,7 @@ module Toc : sig
+
+   val read_data : t -> in_channel -> Obj.t array
+
+-  val read_crcs : t -> in_channel -> (string * Digest.t option) list
++  val read_crcs : t -> in_channel -> Import_info.t array
+
+   val read_prim : t -> in_channel -> string
+
+@@ -2570,9 +2574,10 @@ end = struct
+   let read_crcs toc ic =
+     ignore (seek_section toc ic "CRCS");
+     let orig_crcs : Import_info.t array = input_value ic in
+-    List.map (Array.to_list orig_crcs) ~f:(fun import ->
+-      Import_info.name import |> Compilation_unit.Name.to_string,
+-      Import_info.crc import)
++    orig_crcs
++    (* List.map (Array.to_list orig_crcs) ~f:(fun import -> *)
++    (*   Import_info.name import |> Compilation_unit.Name.to_string, *)
++    (*   Import_info.crc import) *)
+
+   let read_prim toc ic =
+     let prim_size = seek_section toc ic "PRIM" in
+@@ -2587,12 +2592,13 @@ let read_primitives toc ic =
+
+ type bytesections =
+   { symb : Ocaml_compiler.Symtable.GlobalMap.t
+-  ; crcs : (string * Digest.t option) list
++  ; crcs : Import_info.t array
+   ; prim : string list
+   ; dlpt : string list
+   }
+ [@@ocaml.warning "-unused-field"]
+
++
+ let from_exe
+     ?(includes = [])
+     ~linkall
+@@ -2625,7 +2631,7 @@ let from_exe
+       | Some l -> List.mem s ~set:l
+       | None -> true)
+   in
+-  let crcs = List.filter ~f:(fun (unit, _crc) -> keep unit) orig_crcs in
++  let crcs = List.filter ~f:(fun info -> keep (crc_name info)) (Array.to_list orig_crcs) in
+   let symbols =
+     Ocaml_compiler.Symtable.GlobalMap.filter
+       (function
+@@ -2690,7 +2696,7 @@ let from_exe
+         |> Array.of_list
+       in
+       (* Include linking information *)
+-      let sections = { symb = symbols; crcs; prim = primitives; dlpt = [] } in
++      let sections = { symb = symbols; crcs = Array.of_list crcs; prim = primitives; dlpt = [] } in
+       let gdata = Var.fresh () in
+       let need_gdata = ref false in
+       let infos =
+diff --git a/compiler/lib/parse_bytecode.mli b/compiler/lib/parse_bytecode.mli
+index 7bcc822..b34113b 100644
+--- a/compiler/lib/parse_bytecode.mli
++++ b/compiler/lib/parse_bytecode.mli
+@@ -91,5 +91,5 @@ val predefined_exceptions : unit -> Code.program * Unit_info.t
+ val link_info :
+      symbols:Ocaml_compiler.Symtable.GlobalMap.t
+   -> primitives:StringSet.t
+-  -> crcs:(string * Digest.t option) list
++  -> crcs:Import_info.t array
+   -> Code.program
+diff --git a/runtime/js/capsule.js b/runtime/js/capsule.js
+new file mode 100644
+index 0000000..0c02acc
+--- /dev/null
++++ b/runtime/js/capsule.js
+@@ -0,0 +1,14 @@
++//Provides: caml_capsule_mutex_new
++function caml_capsule_mutex_new () {
++  return 0;
++}
++
++//Provides: caml_capsule_mutex_lock
++function caml_capsule_mutex_lock () {
++  return 0;
++}
++
++//Provides: caml_capsule_mutex_unlock
++function caml_capsule_mutex_unlock () {
++  return 0;
++}
+diff --git a/runtime/js/dune b/runtime/js/dune
+index f31ffd1..7e76a14 100644
+--- a/runtime/js/dune
++++ b/runtime/js/dune
+@@ -4,6 +4,7 @@
+  (files
+   bigarray.js
+   bigstring.js
++  capsule.js
+   dynlink.js
+   fs.js
+   fs_fake.js
+diff --git a/runtime/js/float32.js b/runtime/js/float32.js
+index 0c60d3d..74bb433 100644
+--- a/runtime/js/float32.js
++++ b/runtime/js/float32.js
+@@ -12,6 +12,11 @@
+     by native programs and vice versa.
+ */
+
++//Provides: caml_is_boot_compiler
++function caml_is_boot_compiler(x) {
++  return 0;
++}
++
+ //Provides: caml_float_of_float32 const
+ function caml_float_of_float32(x) {
+     return x;
+diff --git a/runtime/js/toplevel.js b/runtime/js/toplevel.js
+index 2e4547e..adaffd3 100644
+--- a/runtime/js/toplevel.js
++++ b/runtime/js/toplevel.js
+@@ -94,7 +94,7 @@ function jsoo_toplevel_init_reloc(f) {
+ //Requires: caml_callback
+ //Requires: caml_string_of_uint8_array, caml_ba_to_typed_array
+ //Requires: jsoo_toplevel_compile, caml_failwith
+-//Version: >= 5.2
++//Version: >= 5.3
+ function caml_reify_bytecode(code, debug, _digest) {
+   if (!jsoo_toplevel_compile) {
+     caml_failwith("Toplevel not initialized (jsoo_toplevel_compile)");
+@@ -107,7 +107,7 @@ function caml_reify_bytecode(code, debug, _digest) {
+ //Requires: caml_callback
+ //Requires: caml_string_of_uint8_array, caml_uint8_array_of_bytes
+ //Requires: jsoo_toplevel_compile, caml_failwith
+-//Version: < 5.2
++//Version: < 5.3
+ function caml_reify_bytecode(code, debug, _digest) {
+   if (!jsoo_toplevel_compile) {
+     caml_failwith("Toplevel not initialized (jsoo_toplevel_compile)");
+diff --git a/toplevel/lib/jsooTop.ml b/toplevel/lib/jsooTop.ml
+index a1e5043..93c8ac0 100644
+--- a/toplevel/lib/jsooTop.ml
++++ b/toplevel/lib/jsooTop.ml
+@@ -65,25 +65,8 @@ let refill_lexbuf s p ppf buffer len =
+     p := !p + len'';
+     len''
+
+-[%%if ocaml_version < (4, 14, 0)]
+-let use ffp content =
+-  let fname, oc =
+-    Filename.open_temp_file ~mode:[ Open_binary ] "jsoo_toplevel" "fake_stdin"
+-  in
+-  output_string oc content;
+-  close_out oc;
+-  try
+-    let b = Toploop.use_silently ffp fname in
+-    Sys.remove fname;
+-    b
+-  with e ->
+-    Sys.remove fname;
+-    raise e
+-[%%endif]
+
+-[%%if ocaml_version >= (4, 14, 0)]
+ let use ffp content = Toploop.use_silently ffp (String content)
+-[%%endif]
+
+ let execute printval ?pp_code ?highlight_location pp_answer s =
+   let lb = Lexing.from_function (refill_lexbuf s (ref 0) pp_code) in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-wasm-temp-differences.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-wasm-temp-differences.patch
@@ -1,0 +1,11 @@
+--- a/lib/tests/test_poly_equal.ml
++++ b/lib/tests/test_poly_equal.ml
+@@ -24,7 +24,7 @@
+   assert (obj1 = obj2);
+   assert (not (obj1 = obj2));
+   ()
+-[@@expect.uncaught_exn {| "Assert_failure lib/tests/test_poly_equal.ml:24:2" |}]
++[@@expect.uncaught_exn {| "Assert_failure test_poly_equal.ml:24:2" |}]
+
+ let%expect_test "poly equal neg" =
+   let obj1 = Js.Unsafe.obj [||] in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-with_async_exns.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/js_of_ocaml-with_async_exns.patch
@@ -1,0 +1,91 @@
+--- a/compiler/bin-js_of_ocaml/js_of_ocaml.ml
++++ b/compiler/bin-js_of_ocaml/js_of_ocaml.ml
+@@ -43,31 +43,32 @@
+     | _ -> argv
+   in
+   try
+-    match
+-      Cmdliner.Cmd.eval_value
+-        ~catch:false
+-        ~argv
+-        (Cmdliner.Cmd.group
+-           ~default:Compile.term
+-           (Compile.info "js_of_ocaml")
+-           [ Link.command
+-           ; Build_fs.command
+-           ; Build_runtime.command
+-           ; Print_runtime.command
+-           ; Check_runtime.command
+-           ; Compile.command
+-           ])
+-    with
+-    | Ok (`Ok () | `Help | `Version) ->
+-        if !warnings > 0 && !werror
+-        then (
+-          Format.eprintf "%s: all warnings being treated as errors@." Sys.argv.(0);
+-          exit 1)
+-        else exit 0
+-    | Error `Term -> exit 1
+-    | Error `Parse -> exit Cmdliner.Cmd.Exit.cli_error
+-    | Error `Exn -> ()
+-    (* should not happen *)
++    Sys.with_async_exns (fun () ->
++      match
++        Cmdliner.Cmd.eval_value
++          ~catch:false
++          ~argv
++          (Cmdliner.Cmd.group
++             ~default:Compile.term
++             (Compile.info "js_of_ocaml")
++             [ Link.command
++             ; Build_fs.command
++             ; Build_runtime.command
++             ; Print_runtime.command
++             ; Check_runtime.command
++             ; Compile.command
++             ])
++      with
++      | Ok (`Ok () | `Help | `Version) ->
++          if !warnings > 0 && !werror
++          then (
++            Format.eprintf "%s: all warnings being treated as errors@." Sys.argv.(0);
++            exit 1)
++          else exit 0
++      | Error `Term -> exit 1
++      | Error `Parse -> exit Cmdliner.Cmd.Exit.cli_error
++      | Error `Exn -> ()
++      (* should not happen *))
+   with
+   | (Match_failure _ | Assert_failure _ | Not_found) as exc ->
+       let backtrace = Printexc.get_backtrace () in
+--- a/compiler/bin-jsoo_minify/jsoo_minify.ml
++++ b/compiler/bin-jsoo_minify/jsoo_minify.ml
+@@ -96,10 +96,11 @@
+ 
+ let _ =
+   try
+-    Cmdliner.Cmd.eval
+-      ~catch:false
+-      ~argv:(Jsoo_cmdline.normalize_argv ~warn:(warn "%s") Sys.argv)
+-      main
++    Sys.with_async_exns (fun () ->
++      Cmdliner.Cmd.eval
++        ~catch:false
++        ~argv:(Jsoo_cmdline.normalize_argv ~warn:(warn "%s") Sys.argv)
++        main)
+   with
+   | (Match_failure _ | Assert_failure _ | Not_found) as exc ->
+       let backtrace = Printexc.get_backtrace () in
+--- a/compiler/lib/generate.ml
++++ b/compiler/lib/generate.ml
+@@ -1105,7 +1105,9 @@
+       bool (J.EBin (J.EqEq, cx, cy)));
+   register_bin_prim "caml_js_instanceof" `Mutator (fun cx cy _ ->
+       bool (J.EBin (J.InstanceOf, cx, cy)));
+-  register_un_prim "caml_js_typeof" `Mutator (fun cx _ -> J.EUn (J.Typeof, cx))
++  register_un_prim "caml_js_typeof" `Mutator (fun cx _ -> J.EUn (J.Typeof, cx));
++  register_un_prim "caml_with_async_exns" `Mutator (fun closure loc ->
++      J.call closure [int 0] loc)
+ 
+ (* This is not correct when switching the js-string flag *)
+ (* {[

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-add-bigstring_memrchr.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-add-bigstring_memrchr.patch
@@ -1,0 +1,31 @@
+--- a/runtime/wasm/bigstring.wat
++++ b/runtime/wasm/bigstring.wat
+@@ -188,5 +188,28 @@
+                (br $loop))))
+      (ref.i31 (i32.const -1)))
+ 
++   (func (export "caml_bigstring_memrchr")
++      (param $s (ref eq)) (param $vc (ref eq))
++      (param $vpos (ref eq)) (param $vlen (ref eq)) (result (ref eq))
++      (local $pos i32) (local $cur i32) (local $c i32)
++      (local $d (ref extern))
++      (local.set $c (i31.get_s (ref.cast (ref i31) (local.get $vc))))
++      (local.set $pos (i31.get_s (ref.cast (ref i31) (local.get $vpos))))
++      (local.set $cur (i32.sub
++                         (i32.add (local.get $pos)
++                                  (i31.get_s (ref.cast (ref i31) (local.get $vlen))))
++                         (i32.const 1)))
++      (local.set $d (call $caml_ba_get_data (local.get $s)))
++      (loop $loop
++         (if (i32.ge_s (local.get $cur) (local.get $pos))
++            (then
++               (if (i32.eq (local.get $c)
++                      (call $ta_get_ui8 (local.get $d) (local.get $cur)))
++                  (then
++                     (return (ref.i31 (local.get $cur)))))
++               (local.set $cur (i32.sub (local.get $cur) (i32.const 1)))
++               (br $loop))))
++     (ref.i31 (i32.const -1)))
++
+    (export "caml_bigstring_blit_string_to_ba"
+       (func $caml_bigstring_blit_bytes_to_ba))

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-add-stubs-of-fs-fns.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-add-stubs-of-fs-fns.patch
@@ -1,0 +1,26 @@
+--- a/runtime/wasm/fs.wat
++++ b/runtime/wasm/fs.wat
+@@ -119,6 +119,13 @@
+       (call $caml_raise_no_such_file (local.get 0))
+       (ref.i31 (i32.const 0)))
+
++   (data $caml_create_file "caml_create_file")
++
++   (func (export "caml_create_file")
++      (param (ref eq)) (param (ref eq)) (result (ref eq))
++      (call $caml_raise_no_such_file (local.get 0))
++      (ref.i31 (i32.const 0)))
++
+    (func (export "caml_fs_init") (result (ref eq))
+       (ref.i31 (i32.const 0)))
+
+@@ -130,4 +137,9 @@
+          (catch $javascript_exception
+             (call $caml_handle_sys_error (pop externref))
+             (return (ref.i31 (i32.const 0))))))
++
++   (data $caml_mount_autoload "caml_mount_autoload")
++
++   (func (export "caml_mount_autoload") (param (ref eq)) (param (ref eq)) (result (ref eq))
++      (ref.i31 (i32.const 0)))
+ )

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-backtrace.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-backtrace.patch
@@ -1,0 +1,121 @@
+--- a/compiler/bin-wasm_of_ocaml/compile.ml
++++ b/compiler/bin-wasm_of_ocaml/compile.ml
+@@ -245,7 +245,7 @@
+         | None -> `Fst name)
+   in
+   let t1 = Timer.make () in
+-  let builtin = Js_of_ocaml_compiler_runtime_files.runtime @ builtin in
++  let builtin = Js_of_ocaml_compiler_runtime_files.runtime @ Wasm_of_ocaml_compiler_runtime_files.runtime @ builtin in
+   List.iter builtin ~f:(fun t ->
+       let filename = Builtins.File.name t in
+       let runtimes = Linker.Fragment.parse_builtin t in
+--- /dev/null
++++ b/compiler/lib-runtime-files/wasm/wasm_of_ocaml_compiler_runtime_files.ml
+@@ -0,0 +1,23 @@
++(* Js_of_ocaml compiler
++ * http://www.ocsigen.org/js_of_ocaml/
++ * Copyright (C) 2020 Hugo Heuzard
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU Lesser General Public License as published by
++ * the Free Software Foundation, with linking exception;
++ * either version 2.1 of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
++ *)
++
++ let runtime =
++    Wa_files.[ flags ]
++
++  include Wa_files
+--- a/runtime/wasm/backtrace.wat
++++ b/runtime/wasm/backtrace.wat
+@@ -1,4 +1,6 @@
+ (module
++   (import "bindings" "backtrace_status" (func $backtrace_status (result i32)))
++   (import "bindings" "record_backtrace" (func $record_backtrace (param i32) (result (ref eq))))
+    (import "fail" "caml_invalid_argument"
+       (func $caml_invalid_argument (param (ref eq))))
+
+@@ -9,9 +11,11 @@
+       (param (ref eq)) (result (ref eq))
+       (array.new_fixed $block 1 (ref.i31 (i32.const 0))))
+
++
+    (func (export "caml_backtrace_status")
+       (param (ref eq)) (result (ref eq))
+-      (ref.i31 (i32.const 0)))
++      (ref.i31
++         (call $backtrace_status)))
+
+    (func (export "caml_convert_raw_backtrace")
+       (param (ref eq)) (result (ref eq))
+@@ -48,5 +52,6 @@
+       (ref.i31 (i32.const 0)))
+
+    (func (export "caml_record_backtrace") (param (ref eq)) (result (ref eq))
+-      (ref.i31 (i32.const 0)))
++         (call $record_backtrace
++            (i31.get_s (ref.cast (ref i31) (local.get 0)))))
+ )
+--- /dev/null
++++ b/runtime/wasm/flags.js
+@@ -0,0 +1,2 @@
++//Provides: with_js_error
++var with_js_error = FLAG("with-js-error");
+--- a/runtime/wasm/runtime.js
++++ b/runtime/wasm/runtime.js
+@@ -135,7 +135,35 @@
+     for (var i = 0; i < s.length; i++) h = hash_int(h, s.charCodeAt(i));
+     return h ^ s.length;
+   }
+
++    var caml_record_backtrace_flag = js.with_js_error
++
++    function jsoo_sys_getenv (n) {
++      var process = globalThis.process;
++
++      //nodejs env
++      if(process && process.env && process.env[n] != undefined) {
++        return process.env[n];
++      }
++
++      if(globalThis.jsoo_env && globalThis.jsoo_env[n]) {
++        return globalThis.jsoo_env[n];
++      }
++    }
++
++    (function () {
++      var r = jsoo_sys_getenv("OCAMLRUNPARAM")
++      if(r !== undefined){
++        var l = r.split(",");
++        for(var i = 0; i < l.length; i++){
++          if(l[i] == "b") { caml_record_backtrace_flag = 1; break }
++          else if (l[i].startsWith("b=")) {
++            caml_record_backtrace_flag = +(l[i].slice(2))}
++          else continue;
++        }
++      }
++    }) ()
++
+   function alloc_stat(s, large) {
+     var kind;
+     if (s.isFile()) {
+@@ -403,7 +431,9 @@
+     exit: (n) => isNode && process.exit(n),
+     argv: () => (isNode ? process.argv.slice(1) : ["a.out"]),
+     on_windows: +on_windows,
+-    getenv: (n) => (isNode ? process.env[n] : null),
++    getenv: jsoo_sys_getenv,
++    backtrace_status: () => caml_record_backtrace_flag,
++    record_backtrace: b => caml_record_backtrace_flag=b,
+     system: (c) => {
+       var res = require("node:child_process").spawnSync(c, {
+         shell: true,

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-blake2.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-blake2.patch
@@ -1,0 +1,125 @@
+--- a/runtime/js/blake2.js
++++ b/runtime/js/blake2.js
+@@ -344,3 +344,33 @@
+   caml_blake2_update(ctx, buf, ofs, len);
+   return caml_blake2_final(ctx, hashlen);
+ }
++
++//Provides: blake2_js_for_wasm_create
++//Requires: caml_blake2_create, caml_string_of_jsbytes
++function blake2_js_for_wasm_create(hashlen, key) {
++    let key_jsoo_string = caml_string_of_jsbytes(key);
++    return caml_blake2_create(hashlen, key_jsoo_string);
++}
++
++//Provides: blake2_js_for_wasm_update
++//Requires: caml_blake2_update, caml_string_of_jsbytes
++function blake2_js_for_wasm_update(ctx, buf, ofs, len) {
++    let buf_jsoo_string = caml_string_of_jsbytes(buf);
++    return caml_blake2_update(ctx, buf_jsoo_string, ofs, len);
++}
++
++//Provides: blake2_js_for_wasm_final
++//Requires: caml_blake2_final, caml_jsbytes_of_string
++function blake2_js_for_wasm_final(ctx, hashlen) {
++    return caml_jsbytes_of_string(
++        caml_blake2_final(ctx, hashlen));
++}
++
++//Provides: blake2_js_for_wasm_string
++//Requires: caml_blake2_string, caml_jsbytes_of_string, caml_string_of_jsbytes
++function blake2_js_for_wasm_string(hashlen, key, buf, ofs, len) {
++    let key_jsoo_string = caml_string_of_jsbytes(key);
++    let buf_jsoo_string = caml_string_of_jsbytes(buf);
++    return caml_jsbytes_of_string(
++        caml_blake2_string(hashlen, key_jsoo_string, buf_jsoo_string, ofs, len));
++}
+--- /dev/null
++++ b/runtime/wasm/blake2.wat
+@@ -0,0 +1,86 @@
++(module
++   (import "env" "wrap" (func $wrap (param anyref) (result (ref eq))))
++   (import "env" "unwrap" (func $unwrap (param (ref eq)) (result anyref)))
++   (import "env" "caml_string_of_jsbytes"
++      (func $caml_string_of_jsbytes (param (ref eq)) (result (ref eq))))
++   (import "env" "caml_jsbytes_of_string"
++      (func $caml_jsbytes_of_string (param (ref eq)) (result (ref eq))))
++   (import "env" "print_int"
++      (func $print_int (param (ref eq)) (result (ref eq))))
++
++   (import "js" "blake2_js_for_wasm_create"
++    (func $blake2_js_for_wasm_create
++      (param  (ref eq))
++      (param  anyref)
++      (result anyref)))
++
++   (import "js" "blake2_js_for_wasm_update"
++    (func $blake2_js_for_wasm_update
++      (param  anyref)
++      (param  anyref)
++      (param  (ref eq))
++      (param  (ref eq))
++      (result (ref eq))))
++
++   (import "js" "blake2_js_for_wasm_string"
++    (func $blake2_js_for_wasm_string
++      (param  (ref eq))
++      (param  anyref)
++      (param  anyref)
++      (param  (ref eq))
++      (param  (ref eq))
++      (result anyref)))
++
++   (import "js" "blake2_js_for_wasm_final"
++    (func $blake2_js_for_wasm_final
++      (param  anyref)
++      (param  (ref eq))
++      (result anyref)))
++
++  (func (export "caml_blake2_create")
++      (param $hashlen (ref eq))
++      (param $key (ref eq))
++      (result (ref eq))
++      (return_call $wrap
++        (call $blake2_js_for_wasm_create
++          (local.get $hashlen)
++          (call $unwrap (call $caml_jsbytes_of_string (local.get $key))))))
++
++   (func (export "caml_blake2_update")
++      (param $ctx (ref eq))
++      (param $buf (ref eq))
++      (param $ofs (ref eq))
++      (param $len (ref eq))
++      (result (ref eq))
++      (return_call $blake2_js_for_wasm_update
++        (call $unwrap (local.get $ctx))
++        (call $unwrap (call $caml_jsbytes_of_string (local.get $buf)))
++        (local.get $ofs)
++        (local.get $len)))
++
++  (func (export "caml_blake2_final")
++      (param $ctx (ref eq))
++      (param $hashlen (ref eq))
++      (result (ref eq))
++      (return_call $caml_string_of_jsbytes
++        (call $wrap
++          (call $blake2_js_for_wasm_final
++            (call $unwrap (local.get $ctx))
++            (local.get $hashlen)))))
++
++   (func (export "caml_blake2_string")
++      (param $hashlen (ref eq))
++      (param $key (ref eq))
++      (param $buf (ref eq))
++      (param $ofs (ref eq))
++      (param $len (ref eq))
++      (result (ref eq))
++      (return_call $caml_string_of_jsbytes
++        (call $wrap
++          (call $blake2_js_for_wasm_string
++            (local.get $hashlen)
++            (call $unwrap (call $caml_jsbytes_of_string (local.get $key)))
++            (call $unwrap (call $caml_jsbytes_of_string (local.get $buf)))
++            (local.get $ofs)
++            (local.get $len)))))
++)

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-bring-back-eval.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-bring-back-eval.patch
@@ -1,0 +1,39 @@
+--- a/runtime/wasm/jslib.wat
++++ b/runtime/wasm/jslib.wat
+@@ -6,6 +6,7 @@
+    (import "bindings" "identity" (func $to_int32 (param anyref) (result i32)))
+    (import "bindings" "identity" (func $from_int32 (param i32) (result anyref)))
+    (import "bindings" "from_bool" (func $from_bool (param i32) (result anyref)))
++   (import "bindings" "eval" (func $eval (param anyref) (result anyref)))
+    (import "bindings" "get"
+       (func $get (param (ref extern)) (param anyref) (result anyref)))
+    (import "bindings" "set"
+@@ -113,6 +114,18 @@
+       (ref.i31 (call $strict_equals
+                   (call $unwrap (local.get 0)) (call $unwrap (local.get 1)))))
+
++   (export "caml_pure_js_expr" (func $caml_js_expr))
++   (export "caml_js_var" (func $caml_js_expr))
++   (export "caml_js_eval_string" (func $caml_js_expr))
++   (func $caml_js_expr (export "caml_js_expr")
++      (param (ref eq)) (result (ref eq))
++      (local $s (ref $bytes))
++      (local.set $s (ref.cast (ref $bytes) (local.get 0)))
++      (return_call $wrap
++         (call $eval
++             (call $jsstring_of_bytes
++                (local.get $s)))))
++
+    (func (export "caml_js_global") (param (ref eq)) (result (ref eq))
+       (call $wrap (global.get $global_this)))
+
+--- a/runtime/wasm/runtime.js
++++ b/runtime/wasm/runtime.js
+@@ -149,6 +149,7 @@
+     instanceof: (x, y) => x instanceof y,
+     typeof: (x) => typeof x,
+     equals: (x, y) => x == y,
++    eval: (x) => eval("("+x+")"),
+     strict_equals: (x, y) => x === y,
+     fun_call: (f, o, args) => f.apply(o, args),
+     meth_call: (o, f, args) => o[f].apply(o, args),

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-build-prefix-sourcemaps.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-build-prefix-sourcemaps.patch
@@ -1,0 +1,14 @@
+--- a/compiler/lib-wasm/wat_output.ml
++++ b/compiler/lib-wasm/wat_output.ml
+@@ -536,6 +536,11 @@
+         ]
+     | Event Parse_info.{ src = None | Some ""; _ } -> [ Comment "@" ]
+     | Event Parse_info.{ src = Some src; col; line; _ } ->
++        let src =
++            match Build_path_prefix_map.get_build_path_prefix_map () with
++            | Some map -> Build_path_prefix_map.rewrite map src
++            | None -> src
++        in
+         let loc = Format.sprintf "%s:%d:%d" src line col in
+         [ Comment ("@ " ^ loc) ]
+   and instructions l = List.concat (List.map ~f:instruction l) in

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-caml_ml_set_channel_output.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-caml_ml_set_channel_output.patch
@@ -1,0 +1,19 @@
+--- a/runtime/wasm/io.wat
++++ b/runtime/wasm/io.wat
+@@ -823,6 +823,16 @@
+                (then (call $caml_flush (local.get $ch))))))
+       (ref.i31 (i32.const 0)))
+
++   (data $caml_ml_set_channel_output "caml_ml_set_channel_output")
++
++   (func (export "caml_ml_set_channel_output")
++      (param (ref eq) (ref eq)) (result (ref eq))
++      ;; ZZZ
++      (call $log_str
++         (array.new_data $string $caml_ml_set_channel_output
++            (i32.const 0) (i32.const 26)))
++      (ref.i31 (i32.const 0)))
++
+    (data $caml_ml_set_channel_refill "caml_ml_set_channel_refill")
+
+    (func (export "caml_ml_set_channel_refill")

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-fetch-base-fix.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-fetch-base-fix.patch
@@ -1,0 +1,20 @@
+--- a/runtime/wasm/runtime.js
++++ b/runtime/wasm/runtime.js
+@@ -496,6 +496,7 @@
+     generated,
+   );
+   const options = { builtins: ["js-string", "text-decoder", "text-encoder"] };
++  const fetchBase = globalThis?.document?.currentScript?.src;
+
+   function loadRelative(src) {
+     const path = require("node:path");
+@@ -504,8 +505,7 @@
+     return require("node:fs/promises").readFile(f);
+   }
+   function fetchRelative(src) {
+-    const base = globalThis?.document?.currentScript?.src;
+-    const url = base ? new URL(src, base) : src;
++    const url = fetchBase ? new URL(src, fetchBase) : src;
+     return fetch(url);
+   }
+   const loadCode = isNode ? loadRelative : fetchRelative;

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-gh113.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-gh113.patch
@@ -1,0 +1,81 @@
+--- /dev/null
++++ b/compiler/tests-wasm_of_ocaml/gh112.ml
+@@ -0,0 +1,31 @@
++let construct x = [| x |]
++
++let get (x : float array) = x.(0)
++let get_ (x : _ array) = x.(0)
++
++let set (x : float array) e = x.(0) <- e
++let set_ (x : _ array) e = x.(0) <- e
++
++let a = construct 1.0
++
++let _ = set a 2.0
++
++let _ = assert (Float.equal (get a) 2.0)
++let _ = assert (Float.equal (get_ a) 2.0)
++
++let _ = set_ a 3.0
++
++let _ = assert (Float.equal (get a) 3.0)
++let _ = assert (Float.equal (get_ a) 3.0)
++
++let b = [| 1.0 |]
++
++let _ = set b 2.0
++
++let _ = assert (Float.equal (get b) 2.0)
++let _ = assert (Float.equal (get_ b) 2.0)
++
++let _ = set_ b 3.0
++
++let _ = assert (Float.equal (get b) 3.0)
++let _ = assert (Float.equal (get_ b) 3.0)
+--- a/compiler/lib/wasm/wa_generate.ml
++++ b/compiler/lib/wasm/wa_generate.ml
+@@ -1159,10 +1159,9 @@
+
+ let init () =
+   let l =
+-    [ "caml_make_array", "%identity"
++    [ "caml_ensure_stack_capacity", "%identity"
+-    ; "caml_ensure_stack_capacity", "%identity"
+     ; "caml_callback", "caml_trampoline"
+     ; "caml_checked_nativeint_to_int", "caml_checked_int32_to_int"
+     ]
+   in
+
+--- a/runtime/wasm/array.wat
++++ b/runtime/wasm/array.wat
+@@ -64,6 +64,30 @@
+       (if (i32.eqz (local.get $sz)) (then (return (global.get $empty_array))))
+       (array.new $float_array (f64.const 0) (local.get $sz)))
+
++   (func (export "caml_make_array") (param $vinit (ref eq)) (result (ref eq))
++      (local $init (ref $block)) (local $res (ref $float_array))
++      (local $size i32) (local $i i32)
++      (local.set $init (ref.cast (ref $block) (local.get $vinit)))
++      (local.set $size (array.len (local.get $init)))
++      (if (i32.ne (local.get $size) (i32.const 1))
++         (then
++            (if (ref.test (ref $float)
++                   (array.get $block (local.get $init) (i32.const 1)))
++               (then
++                  (local.set $size (i32.sub (local.get $size) (i32.const 1)))
++                  (local.set $res
++                     (array.new $float_array (f64.const 0) (local.get $size)))
++                  (loop $loop
++                     (array.set $float_array (local.get $res) (local.get $i)
++                        (struct.get $float 0
++                           (ref.cast (ref $float)
++                              (array.get $block (local.get $init)
++                                 (i32.add (local.get $i) (i32.const 1))))))
++                     (local.set $i (i32.add (local.get $i) (i32.const 1)))
++                     (br_if $loop (i32.lt_u (local.get $i) (local.get $size))))
++                  (return (local.get $res))))))
++      (return (local.get $init)))
++
+    (func (export "caml_floatarray_unsafe_get")
+       (param $a (ref eq)) (param $i (ref eq)) (result (ref eq))
+       (struct.new $float

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-gh48.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-gh48.patch
@@ -1,0 +1,219 @@
+--- a/compiler/lib/wasm/wa_gc_target.ml
++++ b/compiler/lib/wasm/wa_gc_target.ml
+@@ -1717,19 +1717,18 @@
+ let post_process_function_body = Wa_initialize_locals.f
+
+ let entry_point ~toplevel_fun =
+-  let suspender = Code.Var.fresh () in
+   let code =
+-    let* f =
+-      register_import
+-        ~name:
+-          (if Config.Flag.effects ()
+-           then "caml_cps_initialize_effects"
+-           else "caml_initialize_effects")
+-        (Fun { W.params = [ W.Ref { nullable = true; typ = Extern } ]; result = [] })
++    let* () =
++      if Config.Flag.effects ()
++      then
++        let* f =
++          register_import
++            ~name:"caml_cps_initialize_effects"
++            (Fun { W.params = []; result = [] })
++        in
++        instr (W.CallInstr (f, []))
++      else return ()
+     in
+-    let* _ = add_var suspender in
+-    let* s = load suspender in
+-    let* () = instr (W.CallInstr (f, [ s ])) in
+     let* main =
+       register_import
+         ~name:"caml_main"
+@@ -1737,6 +1736,4 @@
+     in
+     instr (W.CallInstr (main, [ RefFunc toplevel_fun ]))
+   in
+-  ( { W.params = [ W.Ref { nullable = true; typ = Extern } ]; result = [] }
+-  , [ suspender ]
+-  , code )
++  { W.params = []; result = [] }, [], code
+--- a/runtime/wasm/effect.wat
++++ b/runtime/wasm/effect.wat
+@@ -33,8 +33,7 @@
+    (import "bindings" "start_fiber" (func $start_fiber (param (ref eq))))
+    (import "bindings" "suspend_fiber"
+       (func $suspend_fiber
+-         (param externref) (param $f funcref) (param $env eqref)
+-         (result eqref)))
++         (param $f funcref) (param $env eqref) (result anyref)))
+    (import "bindings" "resume_fiber"
+       (func $resume_fiber (param externref) (param (ref eq))))
+
+@@ -60,9 +59,6 @@
+
+    ;; Low-level primitives
+
+-   (global $current_suspender (export "current_suspender") (mut externref)
+-      (ref.null extern))
+-
+    ;; Capturing the current continuation
+
+    (type $cont_func (func (param (ref $pair)) (param (ref eq))))
+@@ -102,7 +98,6 @@
+       (return_call $apply_pair
+          (ref.cast (ref $pair)
+             (call $suspend_fiber
+-               (global.get $current_suspender)
+                (ref.func $apply_continuation)
+                (struct.new $thunk (local.get $f) (local.get $v))))))
+
+@@ -121,7 +116,6 @@
+          (struct
+             (field $handlers (mut (ref $handlers)))
+             (field $cont (ref $cont))
+-            (field $suspender externref)
+             (field $next (ref null $fiber)))))
+
+    (data $effect_unhandled "Effect.Unhandled")
+@@ -178,7 +172,6 @@
+                (ref.func $dummy_fun)
+                (ref.func $uncaught_effect_handler)))
+          (struct.new $cont (ref.func $default_continuation))
+-         (ref.null extern)
+          (ref.null $fiber)))
+
+    ;; Utility functions moving fibers between a continuation and the
+@@ -189,8 +182,6 @@
+       (local.set $f (ref.as_non_null (global.get $stack)))
+       (global.set $stack
+          (struct.get $fiber $next (local.get $f)))
+-      (global.set $current_suspender
+-         (struct.get $fiber $suspender (local.get $f)))
+       (struct.get $fiber $cont (local.get $f)))
+
+    (func $push_stack
+@@ -202,10 +193,7 @@
+                (struct.new $fiber
+                   (struct.get $fiber $handlers (local.get $stack))
+                   (local.get $k)
+-                  (global.get $current_suspender)
+                   (global.get $stack)))
+-            (global.set $current_suspender
+-               (struct.get $fiber $suspender (local.get $stack)))
+             (local.set $k
+                (struct.get $fiber $cont (local.get $stack)))
+             (local.set $stack
+@@ -292,7 +280,6 @@
+          (struct.new $fiber
+              (struct.get $fiber $handlers (global.get $stack))
+              (local.get $k0)
+-             (global.get $current_suspender)
+              (if (result (ref null $fiber))
+                  (ref.test (ref $fiber) (local.get $next_fiber))
+                 (then (ref.cast (ref $fiber) (local.get $next_fiber)))
+@@ -331,12 +318,10 @@
+          (local.tee $cont (call $pop_fiber))
+          (struct.get $cont $cont_func (local.get $cont))))
+
+-   (func (export "caml_start_fiber")
+-      (param $suspender externref) (param $p eqref)
++   (func (export "caml_start_fiber") (param $p eqref)
+       ;; Start executing some code in a new fiber
+       (local $exn (ref eq))
+       (local $res (ref eq))
+-      (global.set $current_suspender (local.get $suspender))
+       (local.set $res
+          (try (result (ref eq))
+             (do
+@@ -366,7 +351,6 @@
+       (struct.new $fiber
+          (struct.new $handlers (local.get $hv) (local.get $hx) (local.get $hf))
+          (struct.new $cont (ref.func $initial_cont))
+-         (ref.null extern)
+          (ref.null $fiber)))
+
+    ;; Other functions
+@@ -414,9 +398,6 @@
+                (ref.i31 (global.get $cont_tag))))))
+       (i32.const 0))
+
+-   (func (export "caml_initialize_effects") (param $s externref)
+-      (global.set $current_suspender (local.get $s)))
+-
+    ;; Effects through CPS transformation
+
+    (type $function_2
+@@ -749,6 +730,6 @@
+             (local.get $ms)))
+       (call $raise_unhandled (local.get $eff) (ref.i31 (i32.const 0))))
+
+-   (func (export "caml_cps_initialize_effects") (param externref)
++   (func (export "caml_cps_initialize_effects")
+       (global.set $caml_trampoline_ref (ref.func $caml_trampoline)))
+ )
+--- a/runtime/wasm/runtime.js
++++ b/runtime/wasm/runtime.js
+@@ -110,14 +110,11 @@
+
+   var start_fiber;
+
+-  function wrap_fun(t, f, a) {
+-    // Don't wrap if js-promise-integration is not enabled
+-    // There is no way to check this without calling WebAssembly.Function
+-    try {
+-      return new WebAssembly.Function(t, f, a);
+-    } catch (e) {
+-      return f;
+-    }
++  function make_suspending(f) {
++    return WebAssembly?.Suspending ? new WebAssembly.Suspending(f) : f;
++  }
++  function make_promising(f) {
++    return WebAssembly?.promising ? WebAssembly.promising(f) : f;
+   }
+
+   const decoder = new TextDecoder("utf-8", { ignoreBOM: 1 });
+@@ -424,11 +421,7 @@
+       throw e;
+     },
+     start_fiber: (x) => start_fiber(x),
+-    suspend_fiber: wrap_fun(
+-      { parameters: ["externref", "funcref", "eqref"], results: ["eqref"] },
+-      (f, env) => new Promise((k) => f(k, env)),
+-      { suspending: "first" },
+-    ),
++    suspend_fiber: make_suspending((f, env) => new Promise((k) => f(k, env))),
+     resume_fiber: (k, v) => k(v),
+     weak_new: (v) => new WeakRef(v),
+     weak_deref: (w) => {
+@@ -530,16 +523,8 @@
+   var buffer = caml_buffer?.buffer;
+   var out_buffer = buffer && new Uint8Array(buffer, 0, buffer.length);
+
+-  start_fiber = wrap_fun(
+-    { parameters: ["eqref"], results: ["externref"] },
+-    caml_start_fiber,
+-    { promising: "first" },
+-  );
+-  var _initialize = wrap_fun(
+-    { parameters: [], results: ["externref"] },
+-    _initialize,
+-    { promising: "first" },
+-  );
++  start_fiber = make_promising(caml_start_fiber);
++  var _initialize = make_promising(_initialize);
+   var process = globalThis.process;
+   if (process && process.on) {
+     process.on("uncaughtException", (err, origin) =>
+--- a/runtime/wasm/runtime.js
++++ b/runtime/wasm/runtime.js
+@@ -114,7 +114,7 @@
+     return WebAssembly?.Suspending ? new WebAssembly.Suspending(f) : f;
+   }
+   function make_promising(f) {
+-    return WebAssembly?.promising ? WebAssembly.promising(f) : f;
++    return WebAssembly?.promising && f ? WebAssembly.promising(f) : f;
+   }
+
+   const decoder = new TextDecoder("utf-8", { ignoreBOM: 1 });

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-iter_props-bug.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-iter_props-bug.patch
@@ -1,0 +1,11 @@
+--- a/runtime/wasm/runtime.js
++++ b/runtime/wasm/runtime.js
+@@ -183,7 +183,7 @@
+     new: (c, args) => new c(...args),
+     global_this: globalThis,
+     iter_props: (o, f) => {
+-      for (var nm in o) if (o.hasOwn(nm)) f(nm);
++      for (var nm in o) if (Object.hasOwn(o, nm)) f(nm);
+     },
+     array_length: (a) => a.length,
+     array_get: (a, i) => a[i],

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-remove-zzz-log.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-remove-zzz-log.patch
@@ -1,0 +1,11 @@
+--- a/runtime/wasm/runtime.js
++++ b/runtime/wasm/runtime.js
+@@ -350,7 +350,7 @@
+     },
+     map_set: (m, x, v) => m.set(x, v),
+     map_delete: (m, x) => m.delete(x),
+-    log: (x) => console.log("ZZZZZ", x),
++    log: (x) => console.log(x)
+   };
+   const string_ops = {
+     test: (v) => +(typeof v === "string"),

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-sourcemap-contents.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-sourcemap-contents.patch
@@ -1,0 +1,17 @@
+--- a/compiler/bin-wasm_of_ocaml/compile.ml
++++ b/compiler/bin-wasm_of_ocaml/compile.ml
+@@ -226,8 +226,14 @@
+   Option.iter sm ~f:(fun sm ->
+       if not sourcemap_don't_inline_content
+       then
++        let rewrite =
++          match Build_path_prefix_map.get_build_path_prefix_map () with
++          | Some map -> let map = Build_path_prefix_map.flip map in (fun path -> Build_path_prefix_map.rewrite map path)
++          | None -> Fun.id
++        in
+         Wasm_source_map.iter_sources sm (fun i j file ->
++            let file = rewrite file in
+             if Sys.file_exists file && not (Sys.is_directory file)
+             then
+               let sm = Fs.read_file file in
+               Zip.add_entry

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-stub-caml_ml_set_channel_refill.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-stub-caml_ml_set_channel_refill.patch
@@ -1,0 +1,24 @@
+--- a/runtime/wasm/io.wat
++++ b/runtime/wasm/io.wat
+@@ -82,6 +82,8 @@
+       (func $Int64_val (param (ref eq)) (result i64)))
+    (import "fail" "javascript_exception"
+       (tag $javascript_exception (param externref)))
++   (import "fail" "caml_invalid_argument"
++      (func $caml_invalid_argument (param (ref eq))))
+    (import "sys" "caml_handle_sys_error"
+       (func $caml_handle_sys_error (param externref)))
+    (import "bigarray" "caml_ba_get_data"
+@@ -997,4 +999,12 @@
+       (ref.i31
+          (call $caml_getblock_typed_array
+             (local.get $ch) (local.get $d) (local.get $pos) (local.get $len))))
++
++   (@string $caml_ml_set_channel_refill "caml_ml_set_channel_refill not implemented")
++
++   (func (export "caml_ml_set_channel_refill")
++      (param (ref eq)) (param (ref eq)) (result (ref eq))
++      (call $caml_invalid_argument
++         (global.get $caml_ml_set_channel_refill))
++      (ref.i31 (i32.const 0)))
+ )

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-yojson-support.patch
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/files/wasm_of_ocaml-yojson-support.patch
@@ -1,0 +1,85 @@
+--- a/compiler/lib/wasm/wa_source_map.ml
++++ b/compiler/lib/wasm/wa_source_map.ml
+@@ -1,5 +1,26 @@
+ open Stdlib
+
++module Yojson_raw_util = struct
++  exception Type_error of string * Yojson.Raw.t
++
++  let typerr msg js = raise (Type_error (msg, js))
++
++  let to_assoc =  function
++  | `Assoc obj -> obj
++  | js -> typerr "Expected object, got " js
++  ;;
++
++  let assoc name obj = try List.assoc name obj with Not_found -> `Null
++
++  let member name = function
++  | `Assoc obj -> assoc name obj
++  | js -> typerr ("Can't get member '" ^ name ^ "' of non-object type ") js
++  ;;
++
++  let to_option f = function `Null -> None | x -> Some (f x)
++  let to_list = function `List l -> l | js -> typerr "Expected array, got " js
++end
++
+ type resize_data =
+   { mutable i : int
+   ; mutable pos : int array
+@@ -129,16 +150,16 @@
+   | _ -> assert false
+
+ let replace_member assoc m v =
+-  `Assoc ((m, v) :: List.remove_assoc m (Yojson.Raw.Util.to_assoc assoc))
++  `Assoc ((m, v) :: List.remove_assoc m (Yojson_raw_util.to_assoc assoc))
+
+ let resize resize_data sm =
+-  let open Yojson.Raw.Util in
++  let open Yojson_raw_util in
+   let mappings = to_raw_string (member "mappings" sm) in
+   let mappings = resize_mappings resize_data mappings in
+   replace_member sm "mappings" (`Stringlit mappings)
+
+ let is_empty sm =
+-  let open Yojson.Raw.Util in
++  let open Yojson_raw_util in
+   match member "mappings" sm with
+   | `Stringlit "\"\"" -> true
+   | _ -> false
+@@ -170,7 +191,7 @@
+ let raw_string_from_string s = Yojson.Basic.to_string (`String s)
+
+ let iter_sources' sm i f =
+-  let open Yojson.Raw.Util in
++  let open Yojson_raw_util in
+   let l = sm |> member "sources" |> to_option to_list |> Option.value ~default:[] in
+   let single = List.length l = 1 in
+   List.iteri
+@@ -179,7 +200,7 @@
+     l
+
+ let iter_sources sm f =
+-  let open Yojson.Raw.Util in
++  let open Yojson_raw_util in
+   match to_option to_list (member "sections" sm) with
+   | None -> iter_sources' sm None f
+   | Some l ->
+@@ -193,7 +214,7 @@
+   let rewrite_path path =
+     raw_string_from_string (rewrite_path (string_from_raw_string path))
+   in
+-  let open Yojson.Raw.Util in
++  let open Yojson_raw_util in
+   let l = sm |> member "sources" |> to_option to_list |> Option.value ~default:[] in
+   let single = List.length l = 1 in
+   let contents =
+@@ -223,7 +244,7 @@
+   sm
+
+ let insert_source_contents ~rewrite_path sm f =
+-  let open Yojson.Raw.Util in
++  let open Yojson_raw_util in
+   match to_option to_list (member "sections" sm) with
+   | None -> insert_source_contents' ~rewrite_path sm None f
+   | Some l ->

--- a/packages/js_of_ocaml-toplevel.6.0.1+jst/opam
+++ b/packages/js_of_ocaml-toplevel.6.0.1+jst/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 version: "6.0.1+jst"
-name: "js_of_ocaml-compiler"
+name: "js_of_ocaml-toplevel"
 synopsis: "Compiler from OCaml bytecode to JavaScript"
 description:
   "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
@@ -13,25 +13,16 @@ homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
-  "dune"       {>= "3.17"}
-  "ocaml"      {>= "4.08" & < "5.4"}
-  "num"        {with-test}
-  "ppx_expect" {>= "v0.16.1" & with-test}
-  "ppxlib"     {>= "0.15.0" & < "0.36.0" & = "0.33.0+jst"}
-  "re"         {with-test}
-  "cmdliner"   {>= "1.1.0"}
-  "sedlex"     {>= "3.3" & = "3.3+jst"}
-  "qcheck"     {with-test}
-  "menhir"
-  "menhirLib"
-  "menhirSdk"
-  "yojson"     {>= "2.1"}
-  "odoc"       {with-doc}
-]
-depopts: ["ocamlfind"]
-conflicts: [
-  "ocamlfind" {< "1.5.1"}
-  "js_of_ocaml" {< "3.0"}
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "js_of_ocaml-compiler" {= version & = "6.0.1+jst"}
+  "ppxlib"               {>= "0.15" & = "0.33.0+jst"}
+  "ocamlfind" {>= "1.5.1"}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -73,6 +64,7 @@ patches: [
   "js_of_ocaml-jane-street-5.2-compatibility.patch"
   "js_of_ocaml-migrate-labeled-tuples-shims.patch"
   "js_of_ocaml-floatarray_create_local.patch"
+  "wasm_of_ocaml-sourcemap-contents.patch"
   "js_of_ocaml-jane-street-const_null-support.patch"
   "js_of_ocaml-float32.patch"
   "js_of_ocaml-caml_array_append.patch"
@@ -200,6 +192,10 @@ extra-files: [
   [
     "js_of_ocaml-floatarray_create_local.patch"
     "sha256=f17e392acc941dde475cb7be0654037df9b8d550aeae0d96b65394e4c4a1d4ca"
+  ]
+  [
+    "wasm_of_ocaml-sourcemap-contents.patch"
+    "sha256=93b7dddf6313836ce02fbe762c40380e20daefdd8b87ec885ee0f4ef779ad76b"
   ]
   [
     "js_of_ocaml-jane-street-const_null-support.patch"

--- a/packages/js_of_ocaml.6.0.1+jst/files/js_of_ocaml-top-effects.patch
+++ b/packages/js_of_ocaml.6.0.1+jst/files/js_of_ocaml-top-effects.patch
@@ -1,0 +1,16 @@
+diff --git a/runtime/js/jslib.js b/runtime/js/jslib.js
+index 6a711bbb1d..081361a841 100644
+--- a/runtime/js/jslib.js
++++ b/runtime/js/jslib.js
+@@ -134,8 +134,9 @@ function caml_jsoo_flags_use_js_string(unit) {
+ }
+ 
+ //Provides: caml_jsoo_flags_effects
++//Requires: caml_string_of_jsstring
+ function caml_jsoo_flags_effects(unit) {
+-  return CONFIG("effects");
++  return caml_string_of_jsstring(CONFIG("effects"));
+ }
+ 
+ //Provides: caml_wrap_exception const (mutable)
+

--- a/packages/js_of_ocaml.6.0.1+jst/files/js_of_ocaml-toplevel.patch
+++ b/packages/js_of_ocaml.6.0.1+jst/files/js_of_ocaml-toplevel.patch
@@ -1,0 +1,238 @@
+diff --git a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+index 140a53b..d857289 100644
+--- a/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
++++ b/compiler/lib-dynlink/js_of_ocaml_compiler_dynlink.ml
+@@ -4,7 +4,7 @@ module J = Jsoo_runtime.Js
+
+ type bytecode_sections =
+   { symb : Ocaml_compiler.Symtable.GlobalMap.t
+-  ; crcs : (string * Digest.t option) list
++  ; crcs : Import_info.t array
+   ; prim : string list
+   ; dlpt : string list
+   }
+diff --git a/compiler/lib/link_js.ml b/compiler/lib/link_js.ml
+index 68f0c32..3ec9ddc 100644
+--- a/compiler/lib/link_js.ml
++++ b/compiler/lib/link_js.ml
+@@ -426,7 +426,7 @@ let link ~output ~linkall ~mklib ~toplevel ~files ~resolve_sourcemap_url ~(sourc
+             List.fold_left units ~init:StringSet.empty ~f:(fun acc (u : Unit_info.t) ->
+                 StringSet.union acc (StringSet.of_list u.primitives))
+           in
+-          let code = Parse_bytecode.link_info ~symbols:!sym ~primitives ~crcs:[] in
++          let code = Parse_bytecode.link_info ~symbols:!sym ~primitives ~crcs:[||] in
+           let b = Buffer.create 100 in
+           let fmt = Pretty_print.to_buffer b in
+           Driver.configure fmt;
+diff --git a/compiler/lib/parse_bytecode.ml b/compiler/lib/parse_bytecode.ml
+index 79e0c8f..bf8751a 100644
+--- a/compiler/lib/parse_bytecode.ml
++++ b/compiler/lib/parse_bytecode.ml
+@@ -35,6 +35,9 @@ let predefined_exceptions =
+
+ let new_closure_repr = Ocaml_version.compare Ocaml_version.current [ 4; 12 ] >= 0
+
++let crc_name v = Import_info.name v |> Compilation_unit.Name.to_string
++let crc_crc v = Import_info.crc v
++
+ (* Read and manipulate debug section *)
+ module Debug : sig
+   type t
+@@ -76,11 +79,11 @@ module Debug : sig
+     -> unit
+
+   val read :
+-    t -> crcs:(string * string option) list -> includes:string list -> in_channel -> unit
++    t -> crcs:Import_info.t list -> includes:string list -> in_channel -> unit
+
+   val read_event_list :
+        t
+-    -> crcs:(string * string option) list
++    -> crcs:Import_info.t list
+     -> includes:string list
+     -> orig:int
+     -> in_channel
+@@ -146,6 +149,7 @@ end = struct
+     | Some _ as x -> x
+     | None -> Fs.find_in_path paths (name ^ ".ml")
+
++
+   let read_event
+       ~paths
+       ~crcs
+@@ -216,7 +220,7 @@ end = struct
+     fun debug ~crcs ~includes ~orig ic ->
+       let crcs =
+         let t = Hashtbl.create 17 in
+-        List.iter crcs ~f:(fun (m, crc) -> Hashtbl.add t m crc);
++        List.iter crcs ~f:(fun i -> Hashtbl.add t (crc_name i) (crc_crc i));
+         t
+       in
+       let evl : debug_event list = input_value ic in
+@@ -2520,7 +2524,7 @@ module Toc : sig
+
+   val read_data : t -> in_channel -> Obj.t array
+
+-  val read_crcs : t -> in_channel -> (string * Digest.t option) list
++  val read_crcs : t -> in_channel -> Import_info.t array
+
+   val read_prim : t -> in_channel -> string
+
+@@ -2570,9 +2574,10 @@ end = struct
+   let read_crcs toc ic =
+     ignore (seek_section toc ic "CRCS");
+     let orig_crcs : Import_info.t array = input_value ic in
+-    List.map (Array.to_list orig_crcs) ~f:(fun import ->
+-      Import_info.name import |> Compilation_unit.Name.to_string,
+-      Import_info.crc import)
++    orig_crcs
++    (* List.map (Array.to_list orig_crcs) ~f:(fun import -> *)
++    (*   Import_info.name import |> Compilation_unit.Name.to_string, *)
++    (*   Import_info.crc import) *)
+
+   let read_prim toc ic =
+     let prim_size = seek_section toc ic "PRIM" in
+@@ -2587,12 +2592,13 @@ let read_primitives toc ic =
+
+ type bytesections =
+   { symb : Ocaml_compiler.Symtable.GlobalMap.t
+-  ; crcs : (string * Digest.t option) list
++  ; crcs : Import_info.t array
+   ; prim : string list
+   ; dlpt : string list
+   }
+ [@@ocaml.warning "-unused-field"]
+
++
+ let from_exe
+     ?(includes = [])
+     ~linkall
+@@ -2625,7 +2631,7 @@ let from_exe
+       | Some l -> List.mem s ~set:l
+       | None -> true)
+   in
+-  let crcs = List.filter ~f:(fun (unit, _crc) -> keep unit) orig_crcs in
++  let crcs = List.filter ~f:(fun info -> keep (crc_name info)) (Array.to_list orig_crcs) in
+   let symbols =
+     Ocaml_compiler.Symtable.GlobalMap.filter
+       (function
+@@ -2690,7 +2696,7 @@ let from_exe
+         |> Array.of_list
+       in
+       (* Include linking information *)
+-      let sections = { symb = symbols; crcs; prim = primitives; dlpt = [] } in
++      let sections = { symb = symbols; crcs = Array.of_list crcs; prim = primitives; dlpt = [] } in
+       let gdata = Var.fresh () in
+       let need_gdata = ref false in
+       let infos =
+diff --git a/compiler/lib/parse_bytecode.mli b/compiler/lib/parse_bytecode.mli
+index 7bcc822..b34113b 100644
+--- a/compiler/lib/parse_bytecode.mli
++++ b/compiler/lib/parse_bytecode.mli
+@@ -91,5 +91,5 @@ val predefined_exceptions : unit -> Code.program * Unit_info.t
+ val link_info :
+      symbols:Ocaml_compiler.Symtable.GlobalMap.t
+   -> primitives:StringSet.t
+-  -> crcs:(string * Digest.t option) list
++  -> crcs:Import_info.t array
+   -> Code.program
+diff --git a/runtime/js/capsule.js b/runtime/js/capsule.js
+new file mode 100644
+index 0000000..0c02acc
+--- /dev/null
++++ b/runtime/js/capsule.js
+@@ -0,0 +1,14 @@
++//Provides: caml_capsule_mutex_new
++function caml_capsule_mutex_new () {
++  return 0;
++}
++
++//Provides: caml_capsule_mutex_lock
++function caml_capsule_mutex_lock () {
++  return 0;
++}
++
++//Provides: caml_capsule_mutex_unlock
++function caml_capsule_mutex_unlock () {
++  return 0;
++}
+diff --git a/runtime/js/dune b/runtime/js/dune
+index f31ffd1..7e76a14 100644
+--- a/runtime/js/dune
++++ b/runtime/js/dune
+@@ -4,6 +4,7 @@
+  (files
+   bigarray.js
+   bigstring.js
++  capsule.js
+   dynlink.js
+   fs.js
+   fs_fake.js
+diff --git a/runtime/js/float32.js b/runtime/js/float32.js
+index 0c60d3d..74bb433 100644
+--- a/runtime/js/float32.js
++++ b/runtime/js/float32.js
+@@ -12,6 +12,11 @@
+     by native programs and vice versa.
+ */
+
++//Provides: caml_is_boot_compiler
++function caml_is_boot_compiler(x) {
++  return 0;
++}
++
+ //Provides: caml_float_of_float32 const
+ function caml_float_of_float32(x) {
+     return x;
+diff --git a/runtime/js/toplevel.js b/runtime/js/toplevel.js
+index 2e4547e..adaffd3 100644
+--- a/runtime/js/toplevel.js
++++ b/runtime/js/toplevel.js
+@@ -94,7 +94,7 @@ function jsoo_toplevel_init_reloc(f) {
+ //Requires: caml_callback
+ //Requires: caml_string_of_uint8_array, caml_ba_to_typed_array
+ //Requires: jsoo_toplevel_compile, caml_failwith
+-//Version: >= 5.2
++//Version: >= 5.3
+ function caml_reify_bytecode(code, debug, _digest) {
+   if (!jsoo_toplevel_compile) {
+     caml_failwith("Toplevel not initialized (jsoo_toplevel_compile)");
+@@ -107,7 +107,7 @@ function caml_reify_bytecode(code, debug, _digest) {
+ //Requires: caml_callback
+ //Requires: caml_string_of_uint8_array, caml_uint8_array_of_bytes
+ //Requires: jsoo_toplevel_compile, caml_failwith
+-//Version: < 5.2
++//Version: < 5.3
+ function caml_reify_bytecode(code, debug, _digest) {
+   if (!jsoo_toplevel_compile) {
+     caml_failwith("Toplevel not initialized (jsoo_toplevel_compile)");
+diff --git a/toplevel/lib/jsooTop.ml b/toplevel/lib/jsooTop.ml
+index a1e5043..93c8ac0 100644
+--- a/toplevel/lib/jsooTop.ml
++++ b/toplevel/lib/jsooTop.ml
+@@ -65,25 +65,8 @@ let refill_lexbuf s p ppf buffer len =
+     p := !p + len'';
+     len''
+
+-[%%if ocaml_version < (4, 14, 0)]
+-let use ffp content =
+-  let fname, oc =
+-    Filename.open_temp_file ~mode:[ Open_binary ] "jsoo_toplevel" "fake_stdin"
+-  in
+-  output_string oc content;
+-  close_out oc;
+-  try
+-    let b = Toploop.use_silently ffp fname in
+-    Sys.remove fname;
+-    b
+-  with e ->
+-    Sys.remove fname;
+-    raise e
+-[%%endif]
+
+-[%%if ocaml_version >= (4, 14, 0)]
+ let use ffp content = Toploop.use_silently ffp (String content)
+-[%%endif]
+
+ let execute printval ?pp_code ?highlight_location pp_answer s =
+   let lb = Lexing.from_function (refill_lexbuf s (ref 0) pp_code) in

--- a/packages/js_of_ocaml.6.0.1+jst/opam
+++ b/packages/js_of_ocaml.6.0.1+jst/opam
@@ -71,8 +71,18 @@ patches: [
   "js_of_ocaml-caml_bigstring_strncmp.patch"
   "wasm_of_ocaml-stub-caml_ml_set_channel_refill.patch"
   "dune.patch"
+  "js_of_ocaml-top-effects.patch"
+  "js_of_ocaml-toplevel.patch"
 ]
 extra-files: [
+  [
+   "js_of_ocaml-top-effects.patch"
+   "sha256=638247bd3f7bacb99612353b29c0afdcc48598c5771a52602a96baabbc141370"
+  ]
+  [
+   "js_of_ocaml-toplevel.patch"
+   "sha256=a707bd6825838478839f8f5f70c30ce7a41e11a127b5b913c2638b7c8830d059"
+  ]
   [
     "js_of_ocaml-magic_number.ml.patch"
     "sha256=e15d81f2c5b7b7cf401889b9137571aa6d460afed66e83fd1663257e034b4670"


### PR DESCRIPTION
This PR applies the patches required to get a working toplevel with JS extensions:
 - Most of the diff is just copying the JSOO patches already maintained in the with-extensions branch to the js_of_ocaml-toplevel package
 - js_of_ocaml-top-effects.patch: is https://github.com/ocsigen/js_of_ocaml/pull/1997 as a patch
 - js_of_ocaml-toplevel: the main change here is to align on the types for crcs in CMIs, it also drops some support for older compilers (this could be worked around by getting ppx_optcomp_light to work in some files).