### PR TITLE
Use /usr/bin/env bash, not /bin/bash, in scripts

### DIFF
--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+jst/files/cleanup.patch
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+jst/files/cleanup.patch
@@ -1,9 +1,9 @@
 --- /dev/null
 +++ b/cleanup.sh
 @@ -0,0 +1,23 @@
-+#!/usr/bin/bash -eu
++#!/usr/bin/env bash
 +
-+set -o pipefail
++set -euo pipefail
 +
 +rm -rf bench dev doc examples metaquot metaquot_lifters old_rtd_doc print-diff runner runner_as_ppx src test traverse ppxlib*.opam
 +

--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+jst/files/cleanup.sh
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+jst/files/cleanup.sh
@@ -1,5 +1,5 @@
-#!/bin/bash -eu
-set -o pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
 rm -rf bench dev doc examples metaquot metaquot_lifters old_rtd_doc print-diff runner runner_as_ppx src test traverse ppxlib*.opam
 


### PR DESCRIPTION
for POSIX compliance (specifically nixos, for me.)