### PR TITLE
Add GitHub action to run nightly opam installs of select packages

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,34 @@
+---
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 0 * * *"
+
+jobs:
+  test-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest commit hash on with-extensions branch
+        id: with-extensions-rev
+        run: |
+          HASH=$(git ls-remote https://github.com/janestreet/opam-repository.git refs/heads/with-extensions | cut -f1)
+          echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          # Invalidate cache when with-extensions has new commits, since the
+          # archive URL in the opam file for 5.2.0+flambda2 might have changed.
+          cache-prefix: ${{ steps.with-extensions-rev.outputs.hash }}
+          ocaml-compiler: ocaml-variants.5.2.0+flambda2
+          opam-pin: false
+          opam-repositories: |
+            with-extensions: git+https://github.com/janestreet/opam-repository.git#with-extensions
+            default: https://github.com/ocaml/opam-repository.git
+
+      - name: Run opam install tests
+        run: |
+          opam --version
+          opam list
+          opam repository list
+          opam install ocamlformat.0.26.2+jst merlin.5.2.1-502+jst ocaml-lsp-server.1.19.0+jst utop.2.15.0+jst
+          opam list

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,10 +14,15 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Get latest commit hash on with-extensions branch
+      - name: Checkout with-extensions branch
+        uses: actions/checkout@v4
+        with:
+          ref: with-extensions
+
+      - name: Get latest commit hash
         id: with-extensions-rev
         run: |
-          HASH=$(git ls-remote https://github.com/janestreet/opam-repository.git refs/heads/with-extensions | cut -f1)
+          HASH=$(git rev-parse HEAD)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
 
       - name: Install autoconf on macOS

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,19 +40,10 @@ jobs:
             with-extensions: git+https://github.com/janestreet/opam-repository.git#with-extensions
             default: https://github.com/ocaml/opam-repository.git
 
-      - name: Find and install latest packages
+      - name: opam install packages
         run: |
           opam --version
           opam repository list
           opam list
-          PACKAGES=("ocamlformat" "merlin" "ocaml-lsp-server" "utop")
-          PKGS=""
-          for pkg in "${PACKAGES[@]}"; do
-            latest=$(find packages/$pkg -type f -name 'opam' \
-                      | grep '+jst' | sed -E 's|.*/([^/]+)/opam|\1|' \
-                      | sort -V | tail -1)
-            PKGS="$PKGS $latest"
-          done
-          echo "Installing:$PKGS"
-          opam install $PKGS
+          opam install ocamlformat merlin ocaml-lsp-server utop
           opam list

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,13 +6,23 @@ on:
 
 jobs:
   test-setup:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # For info on the OS versions, architecture, etc., see
+        # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Get latest commit hash on with-extensions branch
         id: with-extensions-rev
         run: |
           HASH=$(git ls-remote https://github.com/janestreet/opam-repository.git refs/heads/with-extensions | cut -f1)
           echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
+
+      - name: Install autoconf on macOS
+        if: startsWith(matrix.os, 'macos')
+        run: brew install autoconf
 
       - uses: ocaml/setup-ocaml@v3
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,10 +40,19 @@ jobs:
             with-extensions: git+https://github.com/janestreet/opam-repository.git#with-extensions
             default: https://github.com/ocaml/opam-repository.git
 
-      - name: Run opam install tests
+      - name: Find and install latest packages
         run: |
           opam --version
-          opam list
           opam repository list
-          opam install ocamlformat.0.26.2+jst merlin.5.2.1-502+jst ocaml-lsp-server.1.19.0+jst utop.2.15.0+jst
+          opam list
+          PACKAGES=("ocamlformat" "merlin" "ocaml-lsp-server" "utop")
+          PKGS=""
+          for pkg in "${PACKAGES[@]}"; do
+            latest=$(find packages/$pkg -type f -name 'opam' \
+                      | grep '+jst' | sed -E 's|.*/([^/]+)/opam|\1|' \
+                      | sort -V | tail -1)
+            PKGS="$PKGS $latest"
+          done
+          echo "Installing:$PKGS"
+          opam install $PKGS
           opam list


### PR DESCRIPTION
This PR enables a GitHub Action that runs nightly to test `opam install`-ing a selected list of packages. Currently, the action will run on Ubuntu (`arm64` and `x64`) and MacOS (`arm64` and `Intel`).  This PR is against the `master` branch, since GitHub needs scheduled/cron actions to be on the default branch (`master`) of the repository. 

I have run the action on my own fork of the repository. The build output is [here](https://github.com/punchagan/opam-repository-jst/actions/runs/15610262907/job/43969269428) for [this workflow file](https://github.com/punchagan/opam-repository-jst/actions/runs/15610262907/workflow).