### PR TITLE
Avoid relying on the shell script having executable permissions

### DIFF
--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
@@ -39,7 +39,7 @@ conflicts: [
   "base-effects"
 ]
 build: [
-  ["./cleanup.sh"]
+  ["sh" "./cleanup.sh"]
   ["dune" "subst"] {dev}
   [
     "dune"


### PR DESCRIPTION
The script does not have executable permission on the Mac, see #70.

The fix is what ocaml/opam#2983 recommends.
