### PR TITLE
Retag to fix `ocaml_simd`

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
@@ -91,9 +91,9 @@ extra-source "init-menhir.tar.gz" {
 }
 url {
   src:
-    "https://github.com/oxcaml/oxcaml/archive/refs/tags/5.2.0minus-11.tar.gz"
+    "https://github.com/oxcaml/oxcaml/archive/refs/tags/5.2.0minus-11-opam.tar.gz"
   checksum:
-    "sha256=23b4418a2c538e072e9a82f2cbd31a8c275a4f5568c1fc1762a0b0580fdfd45c"
+    "sha256=21dc6127a2a16522d2d3df890cb467c2886f1ba9918eb0d2a4d67246f85f072e"
 }
 patches: ["ignore-opam.patch"]
 extra-files: [

--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/files/cleanup.sh
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/files/cleanup.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 rm -rf bench dev doc examples metaquot metaquot_lifters old_rtd_doc print-diff runner runner_as_ppx src test traverse ppxlib*.opam
 

--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
@@ -89,7 +89,7 @@ patches: [
 extra-files: [
   [
     "cleanup.sh"
-    "sha256=85a4af7c00c9184ef93112540a38b5f5de291a8dbe11036cb593231d91c57c6b"
+    "sha256=29db7be4fd7860181a36b8c052d1ef944f32918a7c8d6c74fc9b3e7539916d8c"
   ]
   [
     "ppxlib+ast+ast.ml.patch"

--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
@@ -89,7 +89,7 @@ patches: [
 extra-files: [
   [
     "cleanup.sh"
-    "sha256=155384e36ed934037a17b790b87897af588194ebffa57146c93ccb776c816d7c"
+    "sha256=85a4af7c00c9184ef93112540a38b5f5de291a8dbe11036cb593231d91c57c6b"
   ]
   [
     "ppxlib+ast+ast.ml.patch"


### PR DESCRIPTION
Updates the compiler version to 5.2.0minus-11 + a fix to allow the `ocaml_simd` package to build in bytecode mode. It's now installable via opam. Also removes `set -euo pipefail` in `ppxlib_ast`, since this was causing it to fail under opam's `sandbox.sh` in wsl2/ubuntu.